### PR TITLE
support tokens without audience and scope from claims when using JwtBearerGrant

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -89,7 +89,7 @@ class MockOAuth2Server(
         DefaultOAuth2TokenCallback(
             issuerId,
             subject,
-            audience,
+            audience?.let { listOf(it) },
             claims,
             expiry
         )

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -92,7 +92,7 @@ class AuthorizationCodeHandler(
     private class LoginOAuth2TokenCallback(val login: Login, val OAuth2TokenCallback: OAuth2TokenCallback) : OAuth2TokenCallback {
         override fun issuerId(): String = OAuth2TokenCallback.issuerId()
         override fun subject(tokenRequest: TokenRequest): String = login.username
-        override fun audience(tokenRequest: TokenRequest): String = OAuth2TokenCallback.audience(tokenRequest)
+        override fun audience(tokenRequest: TokenRequest): List<String> = OAuth2TokenCallback.audience(tokenRequest)
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
             OAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {
                 login.acr?.let { put("acr", it) }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/JwtBearerGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/JwtBearerGrantHandler.kt
@@ -31,8 +31,12 @@ class JwtBearerGrantHandler(private val tokenProvider: OAuth2TokenProvider) : Gr
             tokenType = "Bearer",
             accessToken = accessToken.serialize(),
             expiresIn = accessToken.expiresIn(),
-            scope = tokenRequest.scope.toString()
+            scope = receivedClaimsSet.toScope(tokenRequest) as? String ?: throw OAuth2Exception("Scope is not specified in assertion or request")
         )
+    }
+
+    private fun JWTClaimsSet.toScope(tokenRequest: TokenRequest): Any {
+        return getClaim("scope") ?: tokenRequest.scope.toString()
     }
 
     private fun assertion(tokenRequest: TokenRequest): JWTClaimsSet =

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/JwtBearerGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/JwtBearerGrantHandler.kt
@@ -8,6 +8,7 @@ import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.expiresIn
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
+import no.nav.security.mock.oauth2.invalidRequest
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.HttpUrl
@@ -20,7 +21,7 @@ class JwtBearerGrantHandler(private val tokenProvider: OAuth2TokenProvider) : Gr
         oAuth2TokenCallback: OAuth2TokenCallback
     ): OAuth2TokenResponse {
         val tokenRequest = request.asNimbusTokenRequest()
-        val receivedClaimsSet = assertion(tokenRequest)
+        val receivedClaimsSet = tokenRequest.assertion()
         val accessToken = tokenProvider.exchangeAccessToken(
             tokenRequest,
             issuerUrl,
@@ -31,15 +32,17 @@ class JwtBearerGrantHandler(private val tokenProvider: OAuth2TokenProvider) : Gr
             tokenType = "Bearer",
             accessToken = accessToken.serialize(),
             expiresIn = accessToken.expiresIn(),
-            scope = receivedClaimsSet.toScope(tokenRequest) as? String ?: throw OAuth2Exception("Scope is not specified in assertion or request")
+            scope = tokenRequest.responseScope()
         )
     }
 
-    private fun JWTClaimsSet.toScope(tokenRequest: TokenRequest): Any {
-        return getClaim("scope") ?: tokenRequest.scope.toString()
+    private fun TokenRequest.responseScope(): String {
+        return scope?.toString()
+            ?: assertion().getClaim("scope")?.toString()
+            ?: invalidRequest("scope must be specified in request or as a claim in assertion parameter")
     }
 
-    private fun assertion(tokenRequest: TokenRequest): JWTClaimsSet =
-        (tokenRequest.authorizationGrant as? JWTBearerGrant)?.jwtAssertion?.jwtClaimsSet
+    private fun TokenRequest.assertion(): JWTClaimsSet =
+        (this.authorizationGrant as? JWTBearerGrant)?.jwtAssertion?.jwtClaimsSet
             ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "missing required parameter assertion")
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/TokenExchangeGrant.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/TokenExchangeGrant.kt
@@ -9,7 +9,7 @@ val TOKEN_EXCHANGE = GrantType("urn:ietf:params:oauth:grant-type:token-exchange"
 class TokenExchangeGrant(
     val subjectTokenType: String,
     val subjectToken: String,
-    val audience: String
+    val audience: MutableList<String>
 ) : AuthorizationGrant(TOKEN_EXCHANGE) {
 
     override fun toParameters(): MutableMap<String, MutableList<String>> =
@@ -17,7 +17,7 @@ class TokenExchangeGrant(
             "grant_type" to mutableListOf(TOKEN_EXCHANGE.value),
             "subject_token_type" to mutableListOf(subjectTokenType),
             "subject_token" to mutableListOf(subjectToken),
-            "audience" to mutableListOf(audience)
+            "audience" to audience
         )
 
     companion object {
@@ -26,6 +26,8 @@ class TokenExchangeGrant(
                 parameters.require("subject_token_type"),
                 parameters.require("subject_token"),
                 parameters.require("audience")
+                    .split(" ")
+                    .toMutableList()
             )
     }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -72,10 +72,17 @@ class OAuth2TokenProvider {
                 .notBeforeTime(Date.from(now))
                 .issueTime(Date.from(now))
                 .jwtID(UUID.randomUUID().toString())
-                .audience(oAuth2TokenCallback.audience(tokenRequest))
-                .build()
+                .also {
+                    it.toAudience(claimsSet, oAuth2TokenCallback.audience(tokenRequest))
+                }.build()
         )
     }
+
+    private fun JWTClaimsSet.Builder.toAudience(claimsSet: JWTClaimsSet, tokenRequestAudience: String): JWTClaimsSet.Builder {
+        return audience(claimsSet.resourceClaim() ?: tokenRequestAudience)
+    }
+
+    private fun JWTClaimsSet.resourceClaim() = getClaim("resource")?.toString()
 
     private fun createSignedJWT(claimsSet: JWTClaimsSet): SignedJWT {
         val header = JWSHeader.Builder(JWSAlgorithm.RS256)

--- a/src/test/kotlin/no/nav/security/mock/oauth2/MockOAuth2ServerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/MockOAuth2ServerTest.kt
@@ -261,7 +261,7 @@ class MockOAuth2ServerTest {
             DefaultOAuth2TokenCallback(
                 issuerId = "custom",
                 subject = "yolo",
-                audience = "myaud"
+                audience = listOf("myaud")
             )
         )
 
@@ -322,7 +322,7 @@ class MockOAuth2ServerTest {
             DefaultOAuth2TokenCallback(
                 issuerId = "default",
                 subject = "mysub",
-                audience = "muyaud",
+                audience = listOf("muyaud"),
                 claims = mapOf("someclaim" to "claimvalue")
             )
         )

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/JwtBearerGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/JwtBearerGrantIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.security.mock.oauth2.e2e
 import com.nimbusds.oauth2.sdk.GrantType
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
@@ -60,12 +61,13 @@ class JwtBearerGrantIntegrationTest {
             response.refreshToken shouldBe null
             response.issuedTokenType shouldBe null
 
-            response.accessToken?.verify(this.issuerUrl("aad"), this.jwksUrl("aad"))
+            response.accessToken.shouldNotBeNull()
+            response.accessToken.verify(this.issuerUrl("aad"), this.jwksUrl("aad"))
 
-            response.accessToken?.audience shouldContainExactly listOf("scope1")
-            response.accessToken?.issuer shouldBe this.issuerUrl("aad").toString()
-            response.accessToken?.claims?.get("claim1") shouldBe "value1"
-            response.accessToken?.claims?.get("claim2") shouldBe "value2"
+            response.accessToken.audience shouldContainExactly listOf("scope1")
+            response.accessToken.issuer shouldBe this.issuerUrl("aad").toString()
+            response.accessToken.claims["claim1"] shouldBe "value1"
+            response.accessToken.claims["claim2"] shouldBe "value2"
         }
     }
 
@@ -104,12 +106,12 @@ class JwtBearerGrantIntegrationTest {
             response.refreshToken shouldBe null
             response.issuedTokenType shouldBe null
 
-            response.accessToken?.verify(this.issuerUrl("aad"), this.jwksUrl("aad"))
-
-            response.accessToken?.audience shouldContainExactly listOf("aud1")
-            response.accessToken?.issuer shouldBe this.issuerUrl("aad").toString()
-            response.accessToken?.claims?.get("claim1") shouldBe "value1"
-            response.accessToken?.claims?.get("claim2") shouldBe "value2"
+            response.accessToken.shouldNotBeNull()
+            response.accessToken.verify(this.issuerUrl("aad"), this.jwksUrl("aad"))
+            response.accessToken.audience shouldContainExactly listOf("aud1")
+            response.accessToken.issuer shouldBe this.issuerUrl("aad").toString()
+            response.accessToken.claims["claim1"] shouldBe "value1"
+            response.accessToken.claims["claim2"] shouldBe "value2"
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/JwtBearerGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/JwtBearerGrantIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.security.mock.oauth2.e2e
 
 import com.nimbusds.oauth2.sdk.GrantType
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -80,14 +81,16 @@ class JwtBearerGrantIntegrationTest {
                 tokenCallback = DefaultOAuth2TokenCallback(
                     issuerId = "idprovider",
                     subject = "mysub",
+                    audience = emptyList(),
                     claims = mapOf(
                         "claim1" to "value1",
                         "claim2" to "value2",
                         "scope" to "ascope",
-                        "resource" to "aud1"
+                        "resource" to "aud1",
                     )
                 )
             )
+            initialToken.audience.shouldBeEmpty()
 
             val response: ParsedTokenResponse = client.tokenRequest(
                 url = this.tokenEndpointUrl("aad"),
@@ -108,7 +111,6 @@ class JwtBearerGrantIntegrationTest {
 
             response.accessToken.shouldNotBeNull()
             response.accessToken.verify(this.issuerUrl("aad"), this.jwksUrl("aad"))
-            response.accessToken.audience shouldContainExactly listOf("aud1")
             response.accessToken.issuer shouldBe this.issuerUrl("aad").toString()
             response.accessToken.claims["claim1"] shouldBe "value1"
             response.accessToken.claims["claim2"] shouldBe "value2"


### PR DESCRIPTION
I ran in to this problem, adding mockOAuth2Sever to my integration tests in maskinporten repo, integration with idporten. 

I make a token request to exchange my assertion with an access_token. 
(I know the implementation right now do no authenticate, as it is implicit in the assertion signature, _using JWTs as Authorization Grants, the scope MAY be used_, the standard also says: _Authentication of the client is optional_, ref: https://tools.ietf.org/html/rfc7523). 

Before implementation, an request with form post with body containing only grant_type and assertion (no scope). The OAuth2TokenResponse fail and mockOAuth2Sever return **500** on /token endpoint. 

Ive added the ability to first check the claim("scope") as for maskinporten/idporten assertions the "scope" value is in the jwtclaims, now not failing with a "maskinporten" request. As for audience, i was thinking to implement the ability to have a token without audience, tho i ran in some smaller problems,

1. ExchangeAccessToken uses as a default all claims from assertion and overwrite values according to response. Making the aud claim default, as i filtered i found that the verify method for tokenResponse, has aud claim as a default when validating token, so i stopped... 
2. May need som guidance how to solve the issue with "aud" free token responses?  
3. Also added check for setting aud from claims "resource" as it how maskinporten/idporten solves the "aud" not being "mandatory" field in the token, but is extracted from claims.

To add, this solves my problem. But is it the right way? :-D