### PR TITLE
Allow mock server on windows.

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
@@ -7,7 +7,6 @@ import com.natpryce.konfig.intType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
 import java.net.InetAddress
-import java.net.InetSocketAddress
 
 private val config = ConfigurationProperties.systemProperties() overriding
     EnvironmentVariables()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
@@ -6,6 +6,7 @@ import com.natpryce.konfig.Key
 import com.natpryce.konfig.intType
 import com.natpryce.konfig.overriding
 import com.natpryce.konfig.stringType
+import java.net.InetAddress
 import java.net.InetSocketAddress
 
 private val config = ConfigurationProperties.systemProperties() overriding
@@ -26,5 +27,5 @@ fun main() {
         OAuth2Config(
             interactiveLogin = true
         )
-    ).start(InetSocketAddress(0).address, config.server.port)
+    ).start(InetAddress.getByName(config.server.hostname), config.server.port)
 }


### PR DESCRIPTION
Previous version gave e.g. "issuer: "http://[::1]:8080/default""
on well-known url on Windows. Attempt at fix.
This version gives "issuer: "http://127.0.0.1:8080/default"".