### PR TITLE
Proxy aware urls in wellknown document

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandler.kt
@@ -9,6 +9,10 @@ import com.nimbusds.jose.Payload
 import com.nimbusds.jose.crypto.DirectDecrypter
 import com.nimbusds.jose.crypto.DirectEncrypter
 import com.nimbusds.oauth2.sdk.OAuth2Error
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+import javax.crypto.KeyGenerator
+import javax.crypto.SecretKey
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.removeAllEncodedQueryParams
@@ -30,10 +34,6 @@ import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.internal.toHostHeader
-import java.net.URLEncoder
-import java.nio.charset.StandardCharsets
-import javax.crypto.KeyGenerator
-import javax.crypto.SecretKey
 
 private val log = KotlinLogging.logger { }
 
@@ -166,7 +166,7 @@ private fun debuggerAuthorizationRequest(
             OAuth2HttpRequest(
                 headers = Headers.headersOf(),
                 method = "GET",
-                url = it
+                originalUrl = it
             )
         }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -32,14 +32,14 @@ import no.nav.security.mock.oauth2.http.RequestType.WELL_KNOWN
 import no.nav.security.mock.oauth2.missingParameter
 import okhttp3.Headers
 import okhttp3.HttpUrl
-import okhttp3.mockwebserver.RecordedRequest
 
 data class OAuth2HttpRequest(
     val headers: Headers,
     val method: String,
-    val url: HttpUrl,
+    val originalUrl: HttpUrl,
     val body: String? = null
 ) {
+    val url: HttpUrl get() = proxyAwareUrl()
     val formParameters: Parameters = Parameters(body)
     val cookies: Map<String, String> = headers["Cookie"]?.keyValuesToMap(";") ?: emptyMap()
 
@@ -112,10 +112,10 @@ data class OAuth2HttpRequest(
                 .apply {
                     port?.toInt()?.let { port(it) }
                 }
-                .encodedPath(url.encodedPath)
-                .query(this.url.query).build()
+                .encodedPath(originalUrl.encodedPath)
+                .query(originalUrl.query).build()
         } else {
-            url
+            originalUrl
         }
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
@@ -104,7 +104,7 @@ internal class AuthorizationCodeHandlerTest {
         return OAuth2HttpRequest(
             headers = Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"),
             method = "POST",
-            url = "http://localhost/token".toHttpUrl(),
+            originalUrl = "http://localhost/token".toHttpUrl(),
             body = "grant_type=authorization_code&" +
                 "client_id=client1&" +
                 "client_secret=secret&" +

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -12,17 +12,20 @@ internal class OAuth2HttpRequestTest {
         val req1 = OAuth2HttpRequest(
             headers = Headers.headersOf(),
             method = "GET",
-            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req1.proxyAwareUrl().toString() shouldBe "http://localhost:8080/mypath?query=1"
         val req2 = OAuth2HttpRequest(
             headers = Headers.headersOf(
-                "host", "fakedings.nais.io",
-                "x-forwarded-proto", "https",
-                "x-forwarded-port", "444"
+                "host",
+                "fakedings.nais.io",
+                "x-forwarded-proto",
+                "https",
+                "x-forwarded-port",
+                "444"
             ),
             method = "GET",
-            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req2.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io:444/mypath?query=1"
     }
@@ -32,17 +35,20 @@ internal class OAuth2HttpRequestTest {
         val req1 = OAuth2HttpRequest(
             headers = Headers.headersOf(),
             method = "GET",
-            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req1.toWellKnown().issuer shouldBe "http://localhost:8080/mypath"
         val req2 = OAuth2HttpRequest(
             headers = Headers.headersOf(
-                "host", "fakedings.nais.io",
-                "x-forwarded-proto", "https",
-                "x-forwarded-port", "444"
+                "host",
+                "fakedings.nais.io",
+                "x-forwarded-proto",
+                "https",
+                "x-forwarded-port",
+                "444"
             ),
             method = "GET",
-            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req2.toWellKnown().issuer shouldBe "https://fakedings.nais.io:444/mypath"
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -1,0 +1,49 @@
+package no.nav.security.mock.oauth2.http
+
+import io.kotest.matchers.shouldBe
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+
+internal class OAuth2HttpRequestTest {
+
+    @Test
+    fun `proxyAwareUrl should use host header and x-forwarded-for-* `() {
+        val req1 = OAuth2HttpRequest(
+            headers = Headers.headersOf(),
+            method = "GET",
+            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req1.proxyAwareUrl().toString() shouldBe "http://localhost:8080/mypath?query=1"
+        val req2 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host", "fakedings.nais.io",
+                "x-forwarded-proto", "https",
+                "x-forwarded-port", "444"
+            ),
+            method = "GET",
+            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req2.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io:444/mypath?query=1"
+    }
+
+    @Test
+    fun `wellKnown should use proxyAwareUrl when headers are set`() {
+        val req1 = OAuth2HttpRequest(
+            headers = Headers.headersOf(),
+            method = "GET",
+            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req1.toWellKnown().issuer shouldBe "http://localhost:8080/mypath"
+        val req2 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host", "fakedings.nais.io",
+                "x-forwarded-proto", "https",
+                "x-forwarded-port", "444"
+            ),
+            method = "GET",
+            url = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req2.toWellKnown().issuer shouldBe "https://fakedings.nais.io:444/mypath"
+    }
+}


### PR DESCRIPTION
* support running behind a proxy by using host header and x-forwarded-for when creating well known doc