### PR TITLE
support "multisegment" issuer

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -15,10 +15,12 @@ import java.net.InetAddress
 import java.net.URI
 import java.time.Duration
 import java.util.UUID
+import java.util.concurrent.TimeUnit
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.extensions.toAuthorizationEndpointUrl
 import no.nav.security.mock.oauth2.extensions.toEndSessionEndpointUrl
 import no.nav.security.mock.oauth2.extensions.toJwksUrl
+import no.nav.security.mock.oauth2.extensions.toOAuth2AuthorizationServerMetadataUrl
 import no.nav.security.mock.oauth2.extensions.toTokenEndpointUrl
 import no.nav.security.mock.oauth2.extensions.toWellKnownUrl
 import no.nav.security.mock.oauth2.http.MockWebServerWrapper
@@ -32,8 +34,6 @@ import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import okhttp3.HttpUrl
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
-import java.lang.RuntimeException
-import java.util.concurrent.TimeUnit
 
 private val log = KotlinLogging.logger { }
 
@@ -84,6 +84,7 @@ open class MockOAuth2Server(
         } ?: throw UnsupportedOperationException("can only takeRequest when httpServer is of type MockWebServer")
 
     fun wellKnownUrl(issuerId: String): HttpUrl = url(issuerId).toWellKnownUrl()
+    fun oauth2AuthorizationServerMetadataUrl(issuerId: String): HttpUrl = url(issuerId).toOAuth2AuthorizationServerMetadataUrl()
     fun tokenEndpointUrl(issuerId: String): HttpUrl = url(issuerId).toTokenEndpointUrl()
     fun jwksUrl(issuerId: String): HttpUrl = url(issuerId).toJwksUrl()
     fun issuerUrl(issuerId: String): HttpUrl = url(issuerId)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -10,6 +10,8 @@ import com.nimbusds.oauth2.sdk.GrantType.REFRESH_TOKEN
 import com.nimbusds.oauth2.sdk.OAuth2Error
 import com.nimbusds.oauth2.sdk.ParseException
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
+import java.net.URLEncoder
+import java.nio.charset.Charset
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import mu.KotlinLogging
@@ -41,8 +43,6 @@ import no.nav.security.mock.oauth2.login.Login
 import no.nav.security.mock.oauth2.login.LoginRequestHandler
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
-import java.net.URLEncoder
-import java.nio.charset.Charset
 
 private val log = KotlinLogging.logger {}
 
@@ -86,8 +86,10 @@ class OAuth2HttpRequestHandler(
 
     private fun handleEndSessionRequest(request: OAuth2HttpRequest): OAuth2HttpResponse {
         log.debug("handle end session request $request")
-        val postLogoutRedirectUri = request.url.queryParameter("post_logout_redirect_uri") ?: "https://www.nav.no"
-        return redirect(postLogoutRedirectUri)
+        val postLogoutRedirectUri = request.url.queryParameter("post_logout_redirect_uri")
+        return postLogoutRedirectUri?.let {
+            redirect(postLogoutRedirectUri)
+        } ?: html("logged out")
     }
 
     private fun handleAuthenticationRequest(request: OAuth2HttpRequest): OAuth2HttpResponse {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/MockOAuth2ServerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/MockOAuth2ServerTest.kt
@@ -13,6 +13,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
 import java.net.URLEncoder
 import java.time.Duration
+import java.util.concurrent.TimeUnit
 import no.nav.security.mock.oauth2.extensions.verifySignatureAndIssuer
 import no.nav.security.mock.oauth2.http.OAuth2HttpResponse
 import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
@@ -38,7 +39,6 @@ import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
-import java.util.concurrent.TimeUnit
 
 // TODO add more tests for exception handling
 class MockOAuth2ServerTest {
@@ -115,6 +115,7 @@ class MockOAuth2ServerTest {
         assertWellKnownResponseForIssuer("default")
         assertWellKnownResponseForIssuer("foo")
         assertWellKnownResponseForIssuer("bar")
+        assertWellKnownResponseForIssuer("path1/path2/path3")
     }
 
     @Test
@@ -134,16 +135,6 @@ class MockOAuth2ServerTest {
         val response = client.newCall(request).execute()
         assertThat(response.code).isEqualTo(200)
         assertThat(response.body?.string()).isEqualTo("some body")
-    }
-
-    @Test
-    fun noIssuerIdInUrlShouldReturn404() {
-        val request: Request = Request.Builder()
-            .url(server.baseUrl().newBuilder().addPathSegments("/.well-known/openid-configuration").build())
-            .get()
-            .build()
-
-        assertThat(client.newCall(request).execute().code).isEqualTo(404)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/security/mock/oauth2/extensions/HttpUrlExtensionsTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/extensions/HttpUrlExtensionsTest.kt
@@ -1,0 +1,33 @@
+package no.nav.security.mock.oauth2.extensions
+
+import io.kotest.matchers.shouldBe
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+
+internal class HttpUrlExtensionsTest {
+
+    @Test
+    fun `urls with no segments, one segment and multiple segments`() {
+        "http://localhost".toHttpUrl().issuerId() shouldBe ""
+        `verify oauth2 endpoint urls`("http://localhost")
+
+        "http://localhost/path1".toHttpUrl().issuerId() shouldBe "path1"
+        `verify oauth2 endpoint urls`("http://localhost/path1")
+
+        "http://localhost/path1/path2".toHttpUrl().issuerId() shouldBe "path1/path2"
+        `verify oauth2 endpoint urls`("http://localhost/path1/path2")
+    }
+
+    private fun `verify oauth2 endpoint urls`(baseUrl: String) {
+        val httpUrl = baseUrl.toHttpUrl()
+        httpUrl.toIssuerUrl() shouldBe "$baseUrl".toHttpUrl()
+        httpUrl.toWellKnownUrl() shouldBe "$baseUrl/.well-known/openid-configuration".toHttpUrl()
+        httpUrl.toOAuth2AuthorizationServerMetadataUrl() shouldBe "$baseUrl/.well-known/oauth-authorization-server".toHttpUrl()
+        httpUrl.toTokenEndpointUrl() shouldBe "$baseUrl/token".toHttpUrl()
+        httpUrl.toAuthorizationEndpointUrl() shouldBe "$baseUrl/authorize".toHttpUrl()
+        httpUrl.toDebuggerCallbackUrl() shouldBe "$baseUrl/debugger/callback".toHttpUrl()
+        httpUrl.toDebuggerUrl() shouldBe "$baseUrl/debugger".toHttpUrl()
+        httpUrl.toEndSessionEndpointUrl() shouldBe "$baseUrl/endsession".toHttpUrl()
+        httpUrl.toJwksUrl() shouldBe "$baseUrl/jwks".toHttpUrl()
+    }
+}


### PR DESCRIPTION
support "multisegment" issuer
* i.e. issuerId can consist of multiple segments/paths
* example: http://localhost/path1/path2/path3 should yield an `issuerId` of `path1/path2/path3`

