### PR TITLE
configure standalone server/docker image 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import java.time.Duration
 import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
+
 val assertjVersion = "3.19.0"
 val kotlinLoggingVersion = "2.0.4"
 val logbackVersion = "1.2.3"

--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
@@ -1,13 +1,46 @@
 package no.nav.security.mock.oauth2
 
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.security.mock.oauth2.http.MockWebServerWrapper
+import no.nav.security.mock.oauth2.http.NettyWrapper
 import no.nav.security.mock.oauth2.http.OAuth2HttpServer
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
+import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
 
 data class OAuth2Config @JvmOverloads constructor(
     val interactiveLogin: Boolean = false,
     val tokenProvider: OAuth2TokenProvider = OAuth2TokenProvider(),
+    @JsonDeserialize(contentAs = RequestMappingTokenCallback::class)
     val tokenCallbacks: Set<OAuth2TokenCallback> = emptySet(),
+    @JsonDeserialize(using = OAuth2HttpServerDeserializer::class)
     val httpServer: OAuth2HttpServer = MockWebServerWrapper()
-)
+) {
+
+    class OAuth2HttpServerDeserializer : JsonDeserializer<OAuth2HttpServer>() {
+        enum class ServerType {
+            MockWebServerWrapper,
+            NettyWrapper
+        }
+
+        override fun deserialize(p: JsonParser, ctxt: DeserializationContext): OAuth2HttpServer {
+            return when (p.readValueAs<ServerType>(object : TypeReference<ServerType>() {})) {
+                ServerType.NettyWrapper -> NettyWrapper()
+                ServerType.MockWebServerWrapper -> MockWebServerWrapper()
+                else -> throw IllegalArgumentException("unsupported httpServer specified in config")
+            }
+        }
+    }
+
+    companion object {
+        fun fromJson(json: String): OAuth2Config {
+            return jacksonObjectMapper().readValue(json)
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
@@ -1,31 +1,56 @@
 package no.nav.security.mock.oauth2
 
-import java.net.InetAddress
-import java.net.InetSocketAddress
+import no.nav.security.mock.oauth2.StandaloneConfig.hostname
+import no.nav.security.mock.oauth2.StandaloneConfig.oauth2Config
+import no.nav.security.mock.oauth2.StandaloneConfig.port
 import no.nav.security.mock.oauth2.http.NettyWrapper
 import no.nav.security.mock.oauth2.http.OAuth2HttpResponse
 import no.nav.security.mock.oauth2.http.route
+import java.io.File
+import java.io.FileNotFoundException
+import java.net.InetAddress
+import java.net.InetSocketAddress
 
-data class Configuration(
-    val server: Server = Server()
-) {
-    data class Server(
-        val hostname: InetAddress = "SERVER_HOSTNAME".fromEnv()?.let { InetAddress.getByName(it) } ?: InetSocketAddress(0).address,
-        val port: Int = "SERVER_PORT".fromEnv()?.toInt() ?: 8080
-    )
+object StandaloneConfig {
+    const val JSON_CONFIG = "JSON_CONFIG"
+    const val JSON_CONFIG_PATH = "JSON_CONFIG_PATH"
+    const val SERVER_HOSTNAME = "SERVER_HOSTNAME"
+    const val SERVER_PORT = "SERVER_PORT"
+
+    fun hostname(): InetAddress = SERVER_HOSTNAME.fromEnv()
+        ?.let { InetAddress.getByName(it) } ?: InetSocketAddress(0).address
+
+    fun port(): Int = SERVER_PORT.fromEnv()?.toInt() ?: 8080
+
+    fun oauth2Config(): OAuth2Config = with(JSON_CONFIG.fromEnv() ?: JSON_CONFIG_PATH.fromEnv("config.json").readFile()) {
+        if (this != null) {
+            OAuth2Config.fromJson(this)
+        } else {
+            OAuth2Config(
+                interactiveLogin = true,
+                httpServer = NettyWrapper()
+            )
+        }
+    }
+
+    private fun String.readFile(): String? =
+        try {
+            File(this).readText()
+        } catch (e: FileNotFoundException) {
+            null
+        }
 }
 
 fun main() {
-    val config = Configuration()
     MockOAuth2Server(
-        OAuth2Config(
-            interactiveLogin = true,
-            httpServer = NettyWrapper()
-        ),
+        oauth2Config(),
         route("/isalive") {
             OAuth2HttpResponse(status = 200, body = "alive and well")
         }
-    ).start(config.server.hostname, config.server.port)
+    ).apply {
+        start(hostname(), port())
+    }
 }
 
+fun String.fromEnv(default: String): String = System.getenv(this) ?: default
 fun String.fromEnv(): String? = System.getenv(this)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
@@ -22,7 +22,7 @@ object StandaloneConfig {
 
     fun port(): Int = SERVER_PORT.fromEnv()?.toInt() ?: 8080
 
-    fun oauth2Config(): OAuth2Config = with(JSON_CONFIG.fromEnv() ?: JSON_CONFIG_PATH.fromEnv("config.json").readFile()) {
+    fun oauth2Config(): OAuth2Config = with(jsonFromEnv()) {
         if (this != null) {
             OAuth2Config.fromJson(this)
         } else {
@@ -32,6 +32,8 @@ object StandaloneConfig {
             )
         }
     }
+
+    private fun jsonFromEnv() = JSON_CONFIG.fromEnv() ?: JSON_CONFIG_PATH.fromEnv("config.json").readFile()
 
     private fun String.readFile(): String? =
         try {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -22,11 +22,13 @@ import com.nimbusds.oauth2.sdk.auth.ClientAuthentication
 import com.nimbusds.oauth2.sdk.auth.PrivateKeyJWT
 import com.nimbusds.oauth2.sdk.id.Issuer
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
+import com.nimbusds.openid.connect.sdk.OIDCScopeValue
 import com.nimbusds.openid.connect.sdk.Prompt
 import java.time.Duration
 import java.time.Instant
 import java.util.HashSet
 import no.nav.security.mock.oauth2.OAuth2Exception
+import no.nav.security.mock.oauth2.grant.TokenExchangeGrant
 import no.nav.security.mock.oauth2.invalidRequest
 
 fun AuthenticationRequest.isPrompt(): Boolean =
@@ -37,6 +39,13 @@ fun AuthenticationRequest.isPrompt(): Boolean =
 fun TokenRequest.grantType(): GrantType =
     this.authorizationGrant?.type
         ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "missing required parameter grant_type")
+
+fun TokenRequest.scopesWithoutOidcScopes() =
+    scope?.toStringList()?.filterNot { value ->
+        OIDCScopeValue.values().map { it.toString() }.contains(value)
+    } ?: emptyList()
+
+fun TokenRequest.tokenExchangeGrantOrNull(): TokenExchangeGrant? = authorizationGrant as? TokenExchangeGrant
 
 fun TokenRequest.authorizationCode(): AuthorizationCode =
     this.authorizationGrant

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -48,6 +48,7 @@ data class OAuth2HttpRequest(
         val clientAuthentication = ClientAuthentication.parse(httpRequest).requirePrivateKeyJwt(this.url.toString(), 120)
         val tokenExchangeGrant = TokenExchangeGrant.parse(formParameters.map)
 
+        // TODO: add scope if present in request
         return TokenRequest(
             this.url.toUri(),
             clientAuthentication,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -10,6 +10,8 @@ import com.nimbusds.oauth2.sdk.GrantType.REFRESH_TOKEN
 import com.nimbusds.oauth2.sdk.OAuth2Error
 import com.nimbusds.oauth2.sdk.ParseException
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
+import java.net.URLEncoder
+import java.nio.charset.Charset
 import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import mu.KotlinLogging
@@ -41,8 +43,6 @@ import no.nav.security.mock.oauth2.login.Login
 import no.nav.security.mock.oauth2.login.LoginRequestHandler
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
-import java.net.URLEncoder
-import java.nio.charset.Charset
 
 private val log = KotlinLogging.logger {}
 
@@ -86,8 +86,10 @@ class OAuth2HttpRequestHandler(
 
     private fun handleEndSessionRequest(request: OAuth2HttpRequest): OAuth2HttpResponse {
         log.debug("handle end session request $request")
-        val postLogoutRedirectUri = request.url.queryParameter("post_logout_redirect_uri") ?: "https://www.nav.no"
-        return redirect(postLogoutRedirectUri)
+        val postLogoutRedirectUri = request.url.queryParameter("post_logout_redirect_uri")
+        return postLogoutRedirectUri?.let {
+            redirect(postLogoutRedirectUri)
+        } ?: html("logged out")
     }
 
     private fun handleAuthenticationRequest(request: OAuth2HttpRequest): OAuth2HttpResponse {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -90,7 +90,7 @@ class OAuth2TokenProvider {
 
     private fun defaultClaims(
         issuerUrl: HttpUrl,
-        subject: String,
+        subject: String?,
         audience: List<String>,
         nonce: String?,
         additionalClaims: Map<String, Any>,

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -8,6 +8,8 @@
         </layout>
     </appender>
 
+    <logger name="io.netty" level="info" />
+
     <root level="debug">
         <appender-ref ref="stdout"/>
     </root>

--- a/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
@@ -1,0 +1,104 @@
+package no.nav.security.mock.oauth2
+
+import com.fasterxml.jackson.databind.exc.InvalidFormatException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.collections.shouldContainAll
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
+import no.nav.security.mock.oauth2.FullConfig.configJson
+import no.nav.security.mock.oauth2.HttpServerConfig.withMockWebServerWrapper
+import no.nav.security.mock.oauth2.HttpServerConfig.withNettyHttpServer
+import no.nav.security.mock.oauth2.HttpServerConfig.withUnknownHttpServer
+import no.nav.security.mock.oauth2.http.MockWebServerWrapper
+import no.nav.security.mock.oauth2.http.NettyWrapper
+import org.intellij.lang.annotations.Language
+import org.junit.jupiter.api.Test
+
+internal class OAuth2ConfigTest {
+
+    @Test
+    fun `create httpServer from json`() {
+        OAuth2Config.fromJson(withNettyHttpServer).httpServer should beInstanceOf<NettyWrapper>()
+        OAuth2Config.fromJson(withMockWebServerWrapper).httpServer should beInstanceOf<MockWebServerWrapper>()
+        shouldThrow<InvalidFormatException> {
+            OAuth2Config.fromJson(withUnknownHttpServer)
+        }
+    }
+
+    @Test
+    fun `create full config from json with multiple tokenCallbacks`() {
+        val config = OAuth2Config.fromJson(configJson)
+        config.interactiveLogin shouldBe true
+        config.httpServer should beInstanceOf<NettyWrapper>()
+        config.tokenCallbacks.size shouldBe 2
+        config.tokenCallbacks.map {
+            it.issuerId()
+        }.toList() shouldContainAll listOf("issuer1", "issuer2")
+    }
+}
+
+object FullConfig {
+    @Language("json")
+    val configJson = """{
+      "interactiveLogin" : true,
+      "httpServer": "NettyWrapper",
+      "tokenCallbacks": [
+        {
+          "issuerId": "issuer1",
+          "tokenExpiry": 120,
+          "requestMappings": [
+            {
+              "requestParam": "scope",
+              "match": "scope1",
+              "claims": {
+                "sub": "subByScope",
+                "aud": [
+                  "audByScope"
+                ]
+              }
+            }
+          ]
+        },
+        {
+          "issuerId": "issuer2",
+          "requestMappings": [
+            {
+              "requestParam": "someparam",
+              "match": "somevalue",
+              "claims": {
+                "sub": "subBySomeParam",
+                "aud": [
+                  "audBySomeParam"
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+    """.trimIndent()
+}
+
+object HttpServerConfig {
+    @Language("json")
+    val withMockWebServerWrapper = """
+        {
+          "httpServer": "MockWebServerWrapper"
+        }
+    """.trimIndent()
+
+    @Language("json")
+    val withNettyHttpServer = """
+        {
+          "httpServer": "NettyWrapper"
+        }
+    """.trimIndent()
+
+    @Language("json")
+    val withUnknownHttpServer = """
+        {
+          "httpServer": "UnknownServer"
+        }
+    """.trimIndent()
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2ServerKtTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2ServerKtTest.kt
@@ -1,0 +1,54 @@
+package no.nav.security.mock.oauth2
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
+import no.nav.security.mock.oauth2.StandaloneConfig.JSON_CONFIG
+import no.nav.security.mock.oauth2.StandaloneConfig.JSON_CONFIG_PATH
+import no.nav.security.mock.oauth2.StandaloneConfig.hostname
+import no.nav.security.mock.oauth2.StandaloneConfig.oauth2Config
+import no.nav.security.mock.oauth2.StandaloneConfig.port
+import no.nav.security.mock.oauth2.http.NettyWrapper
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.net.InetSocketAddress
+
+internal class StandaloneMockOAuth2ServerKtTest {
+
+    private val configFile = "src/test/resources/config.json"
+
+    @Test
+    fun `load config with no env vars set`() {
+        val config = oauth2Config()
+        config.tokenCallbacks.size shouldBe 0
+        config.interactiveLogin shouldBe true
+        config.httpServer should beInstanceOf<NettyWrapper>()
+        hostname() shouldBe InetSocketAddress(0).address
+        port() shouldBe 8080
+    }
+
+    @Test
+    fun `load oauth2Config from file`() {
+        withEnvironment(JSON_CONFIG_PATH to configFile) {
+            val config = oauth2Config()
+            config.tokenCallbacks.size shouldBe 2
+            config.tokenCallbacks shouldContainExactly tokenCallbacksFromFile()
+        }
+    }
+
+    @Test
+    fun `load oauth2Config from env var`() {
+        val json = File(configFile).readText()
+        withEnvironment(JSON_CONFIG to json) {
+            val config = oauth2Config()
+            config.tokenCallbacks.size shouldBe 2
+            config.tokenCallbacks shouldContainExactly tokenCallbacksFromFile()
+        }
+    }
+
+    private fun tokenCallbacksFromFile() = jacksonObjectMapper().readValue<OAuth2Config>(File(configFile).readText()).tokenCallbacks
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.shouldBe
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import java.util.Base64
@@ -76,12 +75,17 @@ internal class OAuth2TokenCallbackTest {
             }
         }
 
-        @Disabled("fix in callback")
         @Test
-        fun `oidc auth code token request should return client_id as aud from callback`() {
-            val tokenRequest = authCodeRequest("scope" to "openid")
-            DefaultOAuth2TokenCallback().asClue {
-                it.audience(tokenRequest) shouldBe "clientId"
+        fun `oidc auth code token request should return scopes not in OIDC from audience in callback`() {
+            authCodeRequest("scope" to "openid").let { tokenRequest ->
+                DefaultOAuth2TokenCallback().asClue {
+                    it.audience(tokenRequest) shouldBe emptyList()
+                }
+            }
+            authCodeRequest("scope" to "openid scope1").let { tokenRequest ->
+                DefaultOAuth2TokenCallback().asClue {
+                    it.audience(tokenRequest) shouldBe listOf("scope1")
+                }
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -1,0 +1,111 @@
+package no.nav.security.mock.oauth2.token
+
+import com.nimbusds.oauth2.sdk.TokenRequest
+import io.kotest.assertions.asClue
+import io.kotest.assertions.assertSoftly
+import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.shouldBe
+import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.Base64
+
+internal class OAuth2TokenCallbackTest {
+
+    private val clientId = "clientId"
+
+    @Nested
+    inner class RequestMappingTokenCallbacks {
+        val issuer1 = RequestMappingTokenCallback(
+            issuerId = "issuer1",
+            requestMappings = setOf(
+                RequestMapping(
+                    requestParam = "scope",
+                    match = "scope1",
+                    claims = mapOf(
+                        "sub" to "subByScope1",
+                        "aud" to listOf("audByScope1"),
+                        "custom" to "custom1"
+                    )
+                ),
+                RequestMapping(
+                    requestParam = "grant_type",
+                    match = "*",
+                    claims = mapOf(
+                        "sub" to "defaultSub",
+                        "aud" to listOf("defaultAud"),
+                    )
+                )
+            ),
+            tokenExpiry = 120
+        )
+
+        @Test
+        fun `token request with request params matching requestmapping should return specific claims from callback`() {
+            val scopeShouldMatch = clientCredentialsRequest("scope" to "scope1")
+            assertSoftly {
+                issuer1.subject(scopeShouldMatch) shouldBe "subByScope1"
+                issuer1.audience(scopeShouldMatch) shouldBe listOf("audByScope1")
+                issuer1.tokenExpiry() shouldBe 120
+                issuer1.addClaims(scopeShouldMatch) shouldContainAll mapOf("custom" to "custom1")
+            }
+        }
+
+        @Test
+        fun `token request with request params matching wildcard requestmapping should return default claims from callback`() {
+            val shouldMatchAllGrantTypes = clientCredentialsRequest()
+            assertSoftly {
+                issuer1.subject(shouldMatchAllGrantTypes) shouldBe "defaultSub"
+                issuer1.audience(shouldMatchAllGrantTypes) shouldBe listOf("defaultAud")
+                issuer1.tokenExpiry() shouldBe 120
+            }
+        }
+    }
+
+    @Nested
+    inner class DefaultOAuth2TokenCallbacks {
+
+        @Test
+        fun `client credentials request should return client_id as sub from callback`() {
+            val tokenRequest = clientCredentialsRequest()
+            DefaultOAuth2TokenCallback().asClue {
+                it.subject(tokenRequest) shouldBe clientId
+            }
+        }
+
+        @Disabled("fix in callback")
+        @Test
+        fun `oidc auth code token request should return client_id as aud from callback`() {
+            val tokenRequest = authCodeRequest("scope" to "openid")
+            DefaultOAuth2TokenCallback().asClue {
+                it.audience(tokenRequest) shouldBe "clientId"
+            }
+        }
+    }
+
+    private fun authCodeRequest(vararg formParams: Pair<String, String>) =
+        tokenRequest(
+            "grant_type" to "authorization_code",
+            "code" to "123",
+            *formParams
+        )
+
+    private fun clientCredentialsRequest(vararg formParams: Pair<String, String>) =
+        tokenRequest("grant_type" to "client_credentials", *formParams)
+
+    private fun tokenRequest(vararg formParams: Pair<String, String>): TokenRequest =
+        OAuth2HttpRequest(
+            Headers.headersOf(
+                "Content-Type", "application/x-www-form-urlencoded",
+                "Authorization", "Basic ${Base64.getEncoder().encodeToString("$clientId:clientSecret".toByteArray())}"
+            ),
+            "POST",
+            "http://localhost/token".toHttpUrl(),
+            formParams.joinToString("&") {
+                "${it.first}=${it.second}"
+            }
+        ).asNimbusTokenRequest()
+}

--- a/src/test/resources/config.json
+++ b/src/test/resources/config.json
@@ -1,0 +1,37 @@
+{
+  "interactiveLogin": true,
+  "httpServer": "NettyWrapper",
+  "tokenCallbacks": [
+    {
+      "issuerId": "issuer1",
+      "tokenExpiry": 120,
+      "requestMappings": [
+        {
+          "requestParam": "scope",
+          "match": "scope1",
+          "claims": {
+            "sub": "subByScope",
+            "aud": [
+              "audByScope"
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "issuerId": "issuer2",
+      "requestMappings": [
+        {
+          "requestParam": "someparam",
+          "match": "somevalue",
+          "claims": {
+            "sub": "subBySomeParam",
+            "aud": [
+              "audBySomeParam"
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/resources/junit-plattform.properties
+++ b/src/test/resources/junit-plattform.properties
@@ -1,0 +1,1 @@
+junit.jupiter.testinstance.lifecycle.default = per_class


### PR DESCRIPTION
**feat: add `RequestMappingTokenCallback`**
* tokenCallback implementation which can return claims based on token request parameter matching
* make `OAuth2TokenCallback.subject()` nullable to allow for tokens without sub claim

**feat: configure `StandaloneMockOAuth2Server.kt` from env and json**
* support loading `OAuth2Config` from env var or json file
* `httpServer` (type) can be specified from json config
* `tokenCallbacks` can be specified from json config using the `RequestMappingTokenCallback` feature

