### PR TITLE
allow additional claims from tokencallback for `token_exchange` and `jwt_bearer` grants

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -129,7 +129,7 @@ open class MockOAuth2Server(
             override fun toParameters(): MutableMap<String, MutableList<String>> = mutableMapOf()
         }
         return this.config.tokenProvider.exchangeAccessToken(
-            TokenRequest(URI.create("http://mockgrant"), mockGrant),
+            TokenRequest(URI.create("http://mockgrant"), ClientID("mockclientid"), mockGrant),
             issuerUrl,
             jwtClaimsSet,
             DefaultOAuth2TokenCallback(

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/JwtBearerGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/JwtBearerGrantIntegrationTest.kt
@@ -91,6 +91,7 @@ class JwtBearerGrantIntegrationTest {
 
             val response: ParsedTokenResponse = client.tokenRequest(
                 url = this.tokenEndpointUrl(issuerId),
+                basicAuth = Pair("client1", "secret"),
                 parameters = mapOf(
                     "grant_type" to GrantType.JWT_BEARER.value,
                     "assertion" to initialToken.serialize()

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Token.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Token.kt
@@ -20,6 +20,7 @@ import com.nimbusds.oauth2.sdk.GrantType.AUTHORIZATION_CODE
 import com.nimbusds.oauth2.sdk.GrantType.CLIENT_CREDENTIALS
 import com.nimbusds.oauth2.sdk.GrantType.JWT_BEARER
 import com.nimbusds.oauth2.sdk.GrantType.REFRESH_TOKEN
+import com.nimbusds.oauth2.sdk.TokenRequest
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
@@ -35,8 +36,12 @@ import java.util.Date
 import java.util.UUID
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.grant.TOKEN_EXCHANGE
+import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
+import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import java.util.Base64
 
 object ClientAssertionType {
     const val JWT_BEARER = "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
@@ -101,6 +106,19 @@ fun verifyWith(
         }
     }
 }
+
+fun nimbusTokenRequest(clientId: String, vararg formParams: Pair<String, String>): TokenRequest =
+    OAuth2HttpRequest(
+        Headers.headersOf(
+            "Content-Type", "application/x-www-form-urlencoded",
+            "Authorization", "Basic ${Base64.getEncoder().encodeToString("$clientId:clientSecret".toByteArray())}"
+        ),
+        "POST",
+        "http://localhost/token".toHttpUrl(),
+        formParams.joinToString("&") {
+            "${it.first}=${it.second}"
+        }
+    ).asNimbusTokenRequest()
 
 fun String.asJwt(): SignedJWT = SignedJWT.parse(this)
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -1,16 +1,12 @@
 package no.nav.security.mock.oauth2.token
 
-import com.nimbusds.oauth2.sdk.TokenRequest
 import io.kotest.assertions.asClue
 import io.kotest.assertions.assertSoftly
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.shouldBe
-import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
-import okhttp3.Headers
-import okhttp3.HttpUrl.Companion.toHttpUrl
+import no.nav.security.mock.oauth2.testutils.nimbusTokenRequest
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import java.util.Base64
 
 internal class OAuth2TokenCallbackTest {
 
@@ -18,7 +14,7 @@ internal class OAuth2TokenCallbackTest {
 
     @Nested
     inner class RequestMappingTokenCallbacks {
-        val issuer1 = RequestMappingTokenCallback(
+        private val issuer1 = RequestMappingTokenCallback(
             issuerId = "issuer1",
             requestMappings = setOf(
                 RequestMapping(
@@ -91,25 +87,13 @@ internal class OAuth2TokenCallbackTest {
     }
 
     private fun authCodeRequest(vararg formParams: Pair<String, String>) =
-        tokenRequest(
+        nimbusTokenRequest(
+            clientId,
             "grant_type" to "authorization_code",
             "code" to "123",
             *formParams
         )
 
     private fun clientCredentialsRequest(vararg formParams: Pair<String, String>) =
-        tokenRequest("grant_type" to "client_credentials", *formParams)
-
-    private fun tokenRequest(vararg formParams: Pair<String, String>): TokenRequest =
-        OAuth2HttpRequest(
-            Headers.headersOf(
-                "Content-Type", "application/x-www-form-urlencoded",
-                "Authorization", "Basic ${Base64.getEncoder().encodeToString("$clientId:clientSecret".toByteArray())}"
-            ),
-            "POST",
-            "http://localhost/token".toHttpUrl(),
-            formParams.joinToString("&") {
-                "${it.first}=${it.second}"
-            }
-        ).asNimbusTokenRequest()
+        nimbusTokenRequest(clientId, "grant_type" to "client_credentials", *formParams)
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProviderTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProviderTest.kt
@@ -2,12 +2,17 @@ package no.nav.security.mock.oauth2.token
 
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.oauth2.sdk.GrantType
+import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import no.nav.security.mock.oauth2.testutils.nimbusTokenRequest
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
 
 internal class OAuth2TokenProviderTest {
-    private val jwkSet = OAuth2TokenProvider().publicJwkSet()
+    private val tokenProvider = OAuth2TokenProvider()
+    private val jwkSet = tokenProvider.publicJwkSet()
 
     @Test
     fun `public jwks returns public part of JWKs`() =
@@ -19,6 +24,41 @@ internal class OAuth2TokenProviderTest {
             it.keyID shouldNotBe null
             it.keyType shouldBe KeyType.RSA
             it.keyUse shouldBe KeyUse.SIGNATURE
+        }
+    }
+
+    @Test
+    fun `claims from tokencallback should be added to token in tokenExchange`() {
+        val initialToken = tokenProvider.jwt(
+            mapOf(
+                "iss" to "http://initialissuer",
+                "sub" to "initialsubject",
+                "aud" to "initialaudience",
+                "initialclaim" to "initialclaim"
+            )
+        )
+
+        tokenProvider.exchangeAccessToken(
+            tokenRequest = nimbusTokenRequest(
+                "myclient",
+                "grant_type" to GrantType.JWT_BEARER.value,
+                "scope" to "scope1",
+                "assertion" to initialToken.serialize()
+            ),
+            "http://default_if_not_overridden".toHttpUrl(),
+            initialToken.jwtClaimsSet,
+            DefaultOAuth2TokenCallback(
+                claims = mapOf(
+                    "extraclaim" to "extra",
+                    "iss" to "http://overrideissuer"
+                )
+            )
+        ).jwtClaimsSet.asClue {
+            it.issuer shouldBe "http://overrideissuer"
+            it.subject shouldBe "initialsubject"
+            it.audience shouldBe listOf("scope1")
+            it.claims["initialclaim"] shouldBe "initialclaim"
+            it.claims["extraclaim"] shouldBe "extra"
         }
     }
 }


### PR DESCRIPTION
* `TokenProvider.exchangeAccessToken()` will now add claims from the `addClaims()` function from the provided `OAuth2TokenCallback`
* makes it possible to override all claims with claims from tokenCallback if neccessary