### PR TITLE
tokenRequest.scope can be null

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ClientCredentialsGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ClientCredentialsGrantHandler.kt
@@ -26,7 +26,7 @@ internal class ClientCredentialsGrantHandler(
             tokenType = "Bearer",
             accessToken = accessToken.serialize(),
             expiresIn = accessToken.expiresIn(),
-            scope = tokenRequest.scope.toString()
+            scope = tokenRequest.scope?.toString()
         )
     }
 }


### PR DESCRIPTION
Example output which is avoided by this change:
```
2021-04-20 14:44:47 [MockWebServer /127.0.0.1:53750] DEBUG no.nav.security.mock.oauth2.http.OAuth2HttpRequestHandler - handle token request OAuth2HttpRequest(headers=Accept: application/json;charset=UTF-8
Content-Type: application/x-www-form-urlencoded;charset=UTF-8
Authorization: Basic dGVzdF9jbGllbnRfaWQ6dGVzdF9jbGllbnRfc2VjcmV0
User-Agent: Java/15.0.2
Host: localhost:60153
Connection: keep-alive
Content-Length: 29
, method=POST, originalUrl=http://localhost:60153/testIssuer/token, body=grant_type=client_credentials)
2021-04-20 14:55:18 [MockWebServer /127.0.0.1:53750] ERROR no.nav.security.mock.oauth2.http.OAuth2HttpRequestHandler - received exception when handling request.
java.lang.NullPointerException: Cannot invoke "com.nimbusds.oauth2.sdk.Scope.toString()" because the return value of "com.nimbusds.oauth2.sdk.TokenRequest.getScope()" is null
	at no.nav.security.mock.oauth2.grant.ClientCredentialsGrantHandler.tokenResponse(ClientCredentialsGrantHandler.kt:29)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRequestHandler.handleTokenRequest(OAuth2HttpRequestHandler.kt:120)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRequestHandler.handleRequest(OAuth2HttpRequestHandler.kt:71)
	at no.nav.security.mock.oauth2.MockOAuth2Server$router$1.invoke(MockOAuth2Server.kt:52)
	at no.nav.security.mock.oauth2.MockOAuth2Server$router$1.invoke(MockOAuth2Server.kt:41)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRouterKt$routeFromPathAndMethod$1.invoke(OAuth2HttpRouter.kt:58)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRouterKt$routeFromPathAndMethod$1.invoke(OAuth2HttpRouter.kt:50)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRouter.match(OAuth2HttpRouter.kt:27)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRouter.invoke(OAuth2HttpRouter.kt:20)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRouter.invoke(OAuth2HttpRouter.kt:14)
	at no.nav.security.mock.oauth2.http.MockWebServerWrapper$MockWebServerDispatcher.dispatch(OAuth2HttpServer.kt:85)
	at okhttp3.mockwebserver.MockWebServer$SocketHandler.processOneRequest(MockWebServer.kt:600)
	at okhttp3.mockwebserver.MockWebServer$SocketHandler.handle(MockWebServer.kt:551)
	at okhttp3.mockwebserver.MockWebServer$serveConnection$$inlined$execute$1.runOnce(TaskQueue.kt:220)
	at okhttp3.internal.concurrent.TaskRunner.runTask(TaskRunner.kt:116)
	at okhttp3.internal.concurrent.TaskRunner.access$runTask(TaskRunner.kt:42)
	at okhttp3.internal.concurrent.TaskRunner$runnable$1.run(TaskRunner.kt:65)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1130)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:630)
	at java.base/java.lang.Thread.run(Thread.java:832)
```