### PR TITLE
Support different signing keys per issuer (issuerId)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,7 @@ dependencies {
     implementation("org.freemarker:freemarker:$freemarkerVersion")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
+    testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
     testImplementation("io.kotest:kotest-runner-junit5-jvm:$kotestVersion") // for kotest framework
     testImplementation("io.kotest:kotest-assertions-core-jvm:$kotestVersion") // for kotest core jvm assertions
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit5:$kotlinVersion")

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -2,7 +2,6 @@ package no.nav.security.mock.oauth2.http
 
 import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.TokenRequest
-import com.nimbusds.oauth2.sdk.auth.ClientAuthentication
 import com.nimbusds.oauth2.sdk.http.HTTPRequest
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import no.nav.security.mock.oauth2.extensions.clientAuthentication

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -70,7 +70,7 @@ class OAuth2HttpRequestHandler(
                 AUTHORIZATION -> handleAuthenticationRequest(request)
                 TOKEN -> handleTokenRequest(request)
                 END_SESSION -> handleEndSessionRequest(request)
-                JWKS -> json(config.tokenProvider.publicJwkSet().toJSONObject()).also { log.debug("handle jwks request") }
+                JWKS -> handleJwksRequest(request)
                 DEBUGGER -> debuggerRequestHandler.handleDebuggerForm(request).also { log.debug("handle debugger request") }
                 DEBUGGER_CALLBACK -> debuggerRequestHandler.handleDebuggerCallback(request).also { log.debug("handle debugger callback request") }
                 FAVICON -> OAuth2HttpResponse(status = 200)
@@ -83,6 +83,13 @@ class OAuth2HttpRequestHandler(
     }
 
     fun enqueueTokenCallback(oAuth2TokenCallback: OAuth2TokenCallback) = tokenCallbackQueue.add(oAuth2TokenCallback)
+
+    private fun handleJwksRequest(request: OAuth2HttpRequest): OAuth2HttpResponse {
+        log.debug("handle jwks request on url=${request.url}")
+        val issuerId = request.url.issuerId()
+        val jwkSet = config.tokenProvider.publicJwkSet(issuerId)
+        return json(jwkSet.toJSONObject())
+    }
 
     private fun handleEndSessionRequest(request: OAuth2HttpRequest): OAuth2HttpResponse {
         log.debug("handle end session request $request")

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
@@ -143,7 +143,7 @@ class MockOAuth2ServerIntegrationTest {
     @Test
     fun `anyToken should issue token with claims from input and be verifyable by servers keys`() {
         withMockOAuth2Server {
-            val customIssuer = "https://customissuer".toHttpUrl()
+            val customIssuer = "https://customissuer/default".toHttpUrl()
             val token = this.anyToken(
                 customIssuer,
                 mutableMapOf(


### PR DESCRIPTION
* signing key per issuerId will be generated on-demand and reused
* fix #43 

