### PR TITLE
Add ability to specify JWT type in header

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -1,5 +1,6 @@
 package no.nav.security.mock.oauth2
 
+import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.AuthorizationCode
@@ -116,6 +117,7 @@ open class MockOAuth2Server(
         DefaultOAuth2TokenCallback(
             issuerId,
             subject,
+            JOSEObjectType.JWT.type,
             audience?.let { listOf(it) },
             claims,
             expiry

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -93,7 +93,7 @@ internal class AuthorizationCodeHandler(
     private class LoginOAuth2TokenCallback(val login: Login, val OAuth2TokenCallback: OAuth2TokenCallback) : OAuth2TokenCallback {
         override fun issuerId(): String = OAuth2TokenCallback.issuerId()
         override fun subject(tokenRequest: TokenRequest): String = login.username
-        override fun type(tokenRequest: TokenRequest): String = OAuth2TokenCallback.type(tokenRequest)
+        override fun headerType(tokenRequest: TokenRequest): String = OAuth2TokenCallback.headerType(tokenRequest)
         override fun audience(tokenRequest: TokenRequest): List<String> = OAuth2TokenCallback.audience(tokenRequest)
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
             OAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -93,6 +93,7 @@ internal class AuthorizationCodeHandler(
     private class LoginOAuth2TokenCallback(val login: Login, val OAuth2TokenCallback: OAuth2TokenCallback) : OAuth2TokenCallback {
         override fun issuerId(): String = OAuth2TokenCallback.issuerId()
         override fun subject(tokenRequest: TokenRequest): String = login.username
+        override fun type(tokenRequest: TokenRequest): String = OAuth2TokenCallback.type(tokenRequest)
         override fun audience(tokenRequest: TokenRequest): List<String> = OAuth2TokenCallback.audience(tokenRequest)
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
             OAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -93,7 +93,7 @@ internal class AuthorizationCodeHandler(
     private class LoginOAuth2TokenCallback(val login: Login, val OAuth2TokenCallback: OAuth2TokenCallback) : OAuth2TokenCallback {
         override fun issuerId(): String = OAuth2TokenCallback.issuerId()
         override fun subject(tokenRequest: TokenRequest): String = login.username
-        override fun headerType(tokenRequest: TokenRequest): String = OAuth2TokenCallback.headerType(tokenRequest)
+        override fun typeHeader(tokenRequest: TokenRequest): String = OAuth2TokenCallback.typeHeader(tokenRequest)
         override fun audience(tokenRequest: TokenRequest): List<String> = OAuth2TokenCallback.audience(tokenRequest)
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
             OAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -13,7 +13,7 @@ import java.util.UUID
 interface OAuth2TokenCallback {
     fun issuerId(): String
     fun subject(tokenRequest: TokenRequest): String?
-    fun headerType(tokenRequest: TokenRequest): String
+    fun typeHeader(tokenRequest: TokenRequest): String
     fun audience(tokenRequest: TokenRequest): List<String>
     fun addClaims(tokenRequest: TokenRequest): Map<String, Any>
     fun tokenExpiry(): Long
@@ -23,7 +23,7 @@ interface OAuth2TokenCallback {
 open class DefaultOAuth2TokenCallback @JvmOverloads constructor(
     private val issuerId: String = "default",
     private val subject: String = UUID.randomUUID().toString(),
-    private val headerType: String = JOSEObjectType.JWT.type,
+    private val typeHeader: String = JOSEObjectType.JWT.type,
     // needs to be nullable in order to know if a list has explicitly been set, empty list should be a allowable value
     private val audience: List<String>? = null,
     private val claims: Map<String, Any> = emptyMap(),
@@ -39,8 +39,8 @@ open class DefaultOAuth2TokenCallback @JvmOverloads constructor(
         }
     }
 
-    override fun headerType(tokenRequest: TokenRequest): String {
-        return headerType
+    override fun typeHeader(tokenRequest: TokenRequest): String {
+        return typeHeader
     }
 
     override fun audience(tokenRequest: TokenRequest): List<String> {
@@ -76,8 +76,8 @@ data class RequestMappingTokenCallback(
     override fun subject(tokenRequest: TokenRequest): String? =
         requestMappings.getClaimOrNull(tokenRequest, "sub")
 
-    override fun headerType(tokenRequest: TokenRequest): String =
-        requestMappings.getHeaderType(tokenRequest)
+    override fun typeHeader(tokenRequest: TokenRequest): String =
+        requestMappings.getTypeHeader(tokenRequest)
 
     override fun audience(tokenRequest: TokenRequest): List<String> =
         requestMappings.getClaimOrNull(tokenRequest, "aud") ?: emptyList()
@@ -93,15 +93,15 @@ data class RequestMappingTokenCallback(
     private inline fun <reified T> Set<RequestMapping>.getClaimOrNull(tokenRequest: TokenRequest, key: String): T? =
         getClaims(tokenRequest)[key] as? T
 
-    private fun Set<RequestMapping>.getHeaderType(tokenRequest: TokenRequest) =
-        firstOrNull { it.isMatch(tokenRequest) }?.headerType ?: JOSEObjectType.JWT.type
+    private fun Set<RequestMapping>.getTypeHeader(tokenRequest: TokenRequest) =
+        firstOrNull { it.isMatch(tokenRequest) }?.typeHeader ?: JOSEObjectType.JWT.type
 }
 
 data class RequestMapping(
     private val requestParam: String,
     private val match: String = "*",
     val claims: Map<String, Any> = emptyMap(),
-    val headerType: String = JOSEObjectType.JWT.type
+    val typeHeader: String = JOSEObjectType.JWT.type
 ) {
     fun isMatch(tokenRequest: TokenRequest): Boolean =
         tokenRequest.toHTTPRequest().queryParameters[requestParam]?.any {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -42,7 +42,7 @@ class OAuth2TokenProvider {
         nonce,
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
-    ).sign(issuerUrl.issuerId())
+    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.type(tokenRequest))
 
     fun accessToken(
         tokenRequest: TokenRequest,
@@ -56,7 +56,7 @@ class OAuth2TokenProvider {
         nonce,
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
-    ).sign(issuerUrl.issuerId())
+    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.type(tokenRequest))
 
     fun exchangeAccessToken(
         tokenRequest: TokenRequest,
@@ -73,7 +73,7 @@ class OAuth2TokenProvider {
             .audience(oAuth2TokenCallback.audience(tokenRequest))
             .addClaims(oAuth2TokenCallback.addClaims(tokenRequest))
             .build()
-            .sign(issuerUrl.issuerId())
+            .sign(issuerUrl.issuerId(), oAuth2TokenCallback.type(tokenRequest))
     }
 
     @JvmOverloads
@@ -86,16 +86,16 @@ class OAuth2TokenProvider {
                 .expirationTime(Date.from(now.plusSeconds(expiry.toSeconds())))
             builder.addClaims(claims)
             builder.build()
-        }.sign(issuerId)
+        }.sign(issuerId, JOSEObjectType.JWT.type)
 
     private fun rsaKey(issuerId: String): RSAKey = signingKeys.computeIfAbsent(issuerId) { generateRSAKey(issuerId) }
 
-    private fun JWTClaimsSet.sign(issuerId: String): SignedJWT {
+    private fun JWTClaimsSet.sign(issuerId: String, type: String?): SignedJWT {
         val key = rsaKey(issuerId)
         return SignedJWT(
             JWSHeader.Builder(JWSAlgorithm.RS256)
                 .keyID(key.keyID)
-                .type(JOSEObjectType.JWT).build(),
+                .type(JOSEObjectType(type)).build(),
             this
         ).apply {
             sign(RSASSASigner(key.toPrivateKey()))

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -42,7 +42,7 @@ class OAuth2TokenProvider {
         nonce,
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
-    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.type(tokenRequest))
+    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.headerType(tokenRequest))
 
     fun accessToken(
         tokenRequest: TokenRequest,
@@ -56,7 +56,7 @@ class OAuth2TokenProvider {
         nonce,
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
-    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.type(tokenRequest))
+    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.headerType(tokenRequest))
 
     fun exchangeAccessToken(
         tokenRequest: TokenRequest,
@@ -73,7 +73,7 @@ class OAuth2TokenProvider {
             .audience(oAuth2TokenCallback.audience(tokenRequest))
             .addClaims(oAuth2TokenCallback.addClaims(tokenRequest))
             .build()
-            .sign(issuerUrl.issuerId(), oAuth2TokenCallback.type(tokenRequest))
+            .sign(issuerUrl.issuerId(), oAuth2TokenCallback.headerType(tokenRequest))
     }
 
     @JvmOverloads

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -42,7 +42,7 @@ class OAuth2TokenProvider {
         nonce,
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
-    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.headerType(tokenRequest))
+    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.typeHeader(tokenRequest))
 
     fun accessToken(
         tokenRequest: TokenRequest,
@@ -56,7 +56,7 @@ class OAuth2TokenProvider {
         nonce,
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
-    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.headerType(tokenRequest))
+    ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.typeHeader(tokenRequest))
 
     fun exchangeAccessToken(
         tokenRequest: TokenRequest,
@@ -73,7 +73,7 @@ class OAuth2TokenProvider {
             .audience(oAuth2TokenCallback.audience(tokenRequest))
             .addClaims(oAuth2TokenCallback.addClaims(tokenRequest))
             .build()
-            .sign(issuerUrl.issuerId(), oAuth2TokenCallback.headerType(tokenRequest))
+            .sign(issuerUrl.issuerId(), oAuth2TokenCallback.typeHeader(tokenRequest))
     }
 
     @JvmOverloads

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -90,7 +90,7 @@ class OAuth2TokenProvider {
 
     private fun rsaKey(issuerId: String): RSAKey = signingKeys.computeIfAbsent(issuerId) { generateRSAKey(issuerId) }
 
-    private fun JWTClaimsSet.sign(issuerId: String, type: String?): SignedJWT {
+    private fun JWTClaimsSet.sign(issuerId: String, type: String): SignedJWT {
         val key = rsaKey(issuerId)
         return SignedJWT(
             JWSHeader.Builder(JWSAlgorithm.RS256)

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -29,7 +29,7 @@ internal class OAuth2TokenCallbackTest {
                 RequestMapping(
                     requestParam = "scope",
                     match = "scope2",
-                    headerType = "JWT2",
+                    typeHeader = "JWT2",
                     claims = mapOf(
                         "sub" to "subByScope2",
                         "aud" to listOf("audByScope2"),
@@ -66,7 +66,7 @@ internal class OAuth2TokenCallbackTest {
                 issuer1.subject(scopeShouldMatch) shouldBe "subByScope2"
                 issuer1.audience(scopeShouldMatch) shouldBe listOf("audByScope2")
                 issuer1.tokenExpiry() shouldBe 120
-                issuer1.headerType(scopeShouldMatch) shouldBe "JWT2"
+                issuer1.typeHeader(scopeShouldMatch) shouldBe "JWT2"
             }
         }
 
@@ -77,7 +77,7 @@ internal class OAuth2TokenCallbackTest {
                 issuer1.subject(shouldMatchAllGrantTypes) shouldBe "defaultSub"
                 issuer1.audience(shouldMatchAllGrantTypes) shouldBe listOf("defaultAud")
                 issuer1.tokenExpiry() shouldBe 120
-                issuer1.headerType(shouldMatchAllGrantTypes) shouldBe "JWT"
+                issuer1.typeHeader(shouldMatchAllGrantTypes) shouldBe "JWT"
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -27,6 +27,16 @@ internal class OAuth2TokenCallbackTest {
                     )
                 ),
                 RequestMapping(
+                    requestParam = "scope",
+                    match = "scope2",
+                    type = "JWT2",
+                    claims = mapOf(
+                        "sub" to "subByScope2",
+                        "aud" to listOf("audByScope2"),
+                        "custom" to "custom2"
+                    )
+                ),
+                RequestMapping(
                     requestParam = "grant_type",
                     match = "*",
                     claims = mapOf(
@@ -39,7 +49,7 @@ internal class OAuth2TokenCallbackTest {
         )
 
         @Test
-        fun `token request with request params matching requestmapping should return specific claims from callback`() {
+        fun `token request with request params matching requestmapping should return specific claims from callback with default JWT type`() {
             val scopeShouldMatch = clientCredentialsRequest("scope" to "scope1")
             assertSoftly {
                 issuer1.subject(scopeShouldMatch) shouldBe "subByScope1"
@@ -50,12 +60,24 @@ internal class OAuth2TokenCallbackTest {
         }
 
         @Test
+        fun `token request with request params matching requestmapping should return specific claims from callback with non-default JWT type`() {
+            val scopeShouldMatch = clientCredentialsRequest("scope" to "scope2")
+            assertSoftly {
+                issuer1.subject(scopeShouldMatch) shouldBe "subByScope2"
+                issuer1.audience(scopeShouldMatch) shouldBe listOf("audByScope2")
+                issuer1.tokenExpiry() shouldBe 120
+                issuer1.type(scopeShouldMatch) shouldBe "JWT2"
+            }
+        }
+
+        @Test
         fun `token request with request params matching wildcard requestmapping should return default claims from callback`() {
             val shouldMatchAllGrantTypes = clientCredentialsRequest()
             assertSoftly {
                 issuer1.subject(shouldMatchAllGrantTypes) shouldBe "defaultSub"
                 issuer1.audience(shouldMatchAllGrantTypes) shouldBe listOf("defaultAud")
                 issuer1.tokenExpiry() shouldBe 120
+                issuer1.type(shouldMatchAllGrantTypes) shouldBe "JWT"
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -29,7 +29,7 @@ internal class OAuth2TokenCallbackTest {
                 RequestMapping(
                     requestParam = "scope",
                     match = "scope2",
-                    type = "JWT2",
+                    headerType = "JWT2",
                     claims = mapOf(
                         "sub" to "subByScope2",
                         "aud" to listOf("audByScope2"),
@@ -66,7 +66,7 @@ internal class OAuth2TokenCallbackTest {
                 issuer1.subject(scopeShouldMatch) shouldBe "subByScope2"
                 issuer1.audience(scopeShouldMatch) shouldBe listOf("audByScope2")
                 issuer1.tokenExpiry() shouldBe 120
-                issuer1.type(scopeShouldMatch) shouldBe "JWT2"
+                issuer1.headerType(scopeShouldMatch) shouldBe "JWT2"
             }
         }
 
@@ -77,7 +77,7 @@ internal class OAuth2TokenCallbackTest {
                 issuer1.subject(shouldMatchAllGrantTypes) shouldBe "defaultSub"
                 issuer1.audience(shouldMatchAllGrantTypes) shouldBe listOf("defaultAud")
                 issuer1.tokenExpiry() shouldBe 120
-                issuer1.type(shouldMatchAllGrantTypes) shouldBe "JWT"
+                issuer1.headerType(shouldMatchAllGrantTypes) shouldBe "JWT"
             }
         }
     }


### PR DESCRIPTION
In some cases token issuing servers issue tokens with `typ` set to something other than "JWT".

In order to mock those we need to be able to override the default `typ` in the json config.

Example config with custom JWT `typ` of `at+jwt`:

~~~
{
  "tokenCallbacks" : [
    {
      "issuerId" : "default",
      "tokenExpiry" : 12000,
      "requestMappings" : [
        {
          "requestParam" : "client_id",
          "match" : "*",
          "type" : "at+jwt",
          "claims" : {
            "aud" : [
              "my.audience"
            ],
            "scope" : [
              "my.scope1",
              "my.scope2"
            ]
          }
        }
      ]
    }
  ]
}
~~~