### PR TITLE
feat: load some signing keys from file on startup 

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
@@ -19,12 +19,19 @@ import java.io.File
 
 data class OAuth2Config @JvmOverloads constructor(
     val interactiveLogin: Boolean = false,
+    @JsonDeserialize(using = OAuth2TokenProviderDeserializer::class)
     val tokenProvider: OAuth2TokenProvider = OAuth2TokenProvider(),
     @JsonDeserialize(contentAs = RequestMappingTokenCallback::class)
     val tokenCallbacks: Set<OAuth2TokenCallback> = emptySet(),
     @JsonDeserialize(using = OAuth2HttpServerDeserializer::class)
     val httpServer: OAuth2HttpServer = MockWebServerWrapper()
 ) {
+
+    class OAuth2TokenProviderDeserializer : JsonDeserializer<OAuth2TokenProvider>() {
+        override fun deserialize(p0: JsonParser?, p1: DeserializationContext?): OAuth2TokenProvider {
+            return OAuth2TokenProvider()
+        }
+    }
 
     class OAuth2HttpServerDeserializer : JsonDeserializer<OAuth2HttpServer>() {
         enum class ServerType {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -1,0 +1,52 @@
+package no.nav.security.mock.oauth2.token
+
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.RSAKey
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.LinkedBlockingDeque
+
+open class KeyProvider @JvmOverloads constructor(
+    private val initialKeys: List<RSAKey> = keysFromFile(INITIAL_KEYS_FILE)
+) {
+    private val signingKeys: ConcurrentHashMap<String, RSAKey> = ConcurrentHashMap()
+
+    private val generator = KeyPairGenerator.getInstance("RSA").apply { this.initialize(2048) }
+
+    private val keyDeque = LinkedBlockingDeque<RSAKey>().apply {
+        initialKeys.forEach {
+            put(it)
+        }
+    }
+
+    fun signingKey(keyId: String): RSAKey = signingKeys.computeIfAbsent(keyId) { keyFromDequeOrNew(keyId) }
+
+    private fun keyFromDequeOrNew(keyId: String): RSAKey = keyDeque.poll()?.let {
+        RSAKey.Builder(it).keyID(keyId).build()
+    } ?: generator.generateRSAKey(keyId)
+
+    private fun KeyPairGenerator.generateRSAKey(keyId: String): RSAKey =
+        generateKeyPair()
+            .let {
+                RSAKey.Builder(it.public as RSAPublicKey)
+                    .privateKey(it.private as RSAPrivateKey)
+                    .keyUse(KeyUse.SIGNATURE)
+                    .keyID(keyId)
+                    .build()
+            }
+
+    companion object {
+        const val INITIAL_KEYS_FILE = "/mock-oauth2-server-keys.json"
+
+        fun keysFromFile(filename: String): List<RSAKey> {
+            val keysFromFile = KeyProvider::class.java.getResource(filename)
+            if (keysFromFile != null) {
+                return JWKSet.parse(keysFromFile.readText()).keys.map { it as RSAKey }
+            }
+            return emptyList()
+        }
+    }
+}

--- a/src/main/resources/mock-oauth2-server-keys.json
+++ b/src/main/resources/mock-oauth2-server-keys.json
@@ -1,0 +1,69 @@
+{
+  "keys": [
+    {
+      "p": "5riKsMcpImce_BGr13BQv6kA2RuRfW8aiqad7eu3WrdUPBZBGeI7LdISOYtikNij1GSuAnqLVyjPtKL1WDmNiKTo8ArvtZmlCNlEqQzzbUUIQFxUAJ9cMR_mgmoo-jfmia_0wPIVdMpev9Xzg30mAObNT0pj3F968e5ThSRave8",
+      "kty": "RSA",
+      "q": "tEM-X38gszZOAMwVZXQa_GEon3f9sngC6K1lX_TDbTdPoIHdberli70W2-505FEviEvtWf0VZGUbsxVIdWtN7rV9p-Q3__KnFYvj5dtIbZR1-Njgnleya9rmv_7pP3c_p66S0-jeEaXnLHorK3HOsvyzfuRM389BKwapKNdOGbs",
+      "d": "V19sUxBYchl1hbCrlYse7zLds_-lUCPI0xVaMhrw4OEmJhOqJqjNZtkDAcb7DsSyDW-L_Ai5XdXvOZoj8ZdqRO5eFEJtPpyRAmL7_4ZO2DT0ztyOCJu7xc2nBAFiTw25fk9aP2JxFEZTvCPoFMBFThsljS6A7_nvleVa8pD55s3LxBRojqmJZAPeO8he0ju2O2rAWsT8YJX7cgMUDBfE3eTR4riwQrIPh7fihcn0zVbf7DXDSMLaCeedc9EI17A00dwrPQx9eiqByatWMRTodzykTjAJGF06gtivBuVzJTTXUto3n9rBRp9pjxwp4o-u8-aZxJaZLIrDLJLgGv60aQ",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "initialkey-1",
+      "qi": "HqUVnJoG53wI1I3a922NDUWmVYxBa4fAA0nketVgSDbF5XkZTQW3JsC1K0oPqD-HtSz8bQu0JuOaG3ya-DVEGjeC8lpY_WX9rqoyBe-1AtqXOciU98iQwDIs5gARlTVj6q-jr867keNUdF8f9-GCFWqXWo0QFOeyXnOIwNRNJBo",
+      "dp": "V03XdUM3poP87odFTjV66Ltrzbun1x4WngakViZO8G3U2xPUuJWprRIDwXCj8Il5nOIoEloKpgWUaxcK3cKRcvZsCoEo6b_k-i800v9KkbuAftIxGzcyLIiUsh63uM80Vj-VzvkL83CsX8z243eUzNyJLgrJNNeQb0Guqv_xslM",
+      "dq": "pKUijDDeWjHIjzvYcyDYIRpQ806yftbUuVbe2AUElnXFmfHjoKjC3p5oCZtEUuHAS3omIWJirp8W7LwMwYqv1M8aJUXyzCkC6VAraN-fyM6n7hGRH68z_QUka8rVmi0-C9cMrtbsNixU-K_hTD4XsC3VeJnniSiQ-k6MJQx6fk8",
+      "n": "onZcB1ryWS1keTIcbgsLKJ1UBwL1Wbzse5P2HjkrNwbG3Jy2lefUEcTVJxN8bpLeW460Luz3ScZd3d9p8IoHjmhZ2cyO49E41aBRIlBRzWNpebK5xeC95rSKenYHpOPlLzPgybg2qxallzQUOcKCheiF0fsErlapaA9YmKwzP3DwvzYW4JqSrHhDGWPwUCcsR4dpetwKXP_9tRFso06ryr4um3qiq7giyZEyZVG3fHMplD-5e-2-RrzBiGFW_zvs-XVRGPIf9Y5YNjeQJRuS4vF82V8mNZxEZddtUY5plSz-vgX3GSvANLDH-LZJ76Zmx3a8dEZbI7VxgsBQAqcUlQ"
+    },
+    {
+      "p": "8X4E3UUItsFp4JSzLVBvDz7VKZAvQTbngQfvIRokECLdsP--1YGkniit-e9KHR8UtVI3h-cqMmHvffHoqwOdKoxi5BViuwmqCdIfjBvpfQB3PZxOEAFojiRG0apxnXtmxUKG3PIIsFGXG8YhHwLIqwTvwaKr1BF3g6qW2pSzFFs",
+      "kty": "RSA",
+      "q": "3YFMc2Ux4sFcBHqT440beIBmXbEeUZ3jc-728PFXGZRVeTNn9HZSascgO6nw9iECz-jRQwTX4P9RIAnWm782AV5QIGXmz3t-4ssimLHtP9jkyhqTDMmuUUv1QKhdD2p4q_uzbrkx4A3OMphgGDbLe4UKBA-9X10BozoRFXawNds",
+      "d": "EFVtvj1zJ5ixPHVH-4bzDNQK_WJyi8RkxkbVFXmfMdtylh3tWfaNRnuKjiwlCHWT7x0Asof4SYY9YAPvoaq8g79zp4sRL_XmNawLk9QRi0hHHXowwlVK39qQHZ15Q8Hs3s3VDXx6NlVqWBFjTBz2eX-2vwesvPjPQUd2iCXRz8UXtsKRuToE_ddAFLC_Gcz_yPSQCFfyptPhBCPVsI6opsdK_SELuGspvI3ux2Gbq5aWGaByWo5-2NpPfXdiEPcY0mREKfe3kQU0Wa5-vqYA43ekpFaCKSsj-vmmhkP0FwQxBtVs_CVxRfgzyn1_mF2oZsPuvUeJXbHFF-PdjBmz7Q",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "initialkey-2",
+      "qi": "5OHgZtRG6CecHV-2AUlRZtHraN_G3nftrMAGuczh97RdjlEUxia_LkQqc_OUJf8M_57I5WZ4z2H7u1JVzscM3D7nFKJLq2JoW5kc2zffYhZm83mcTWyvQSf6WPvmqxqX2TZr_JFBLn0_33DQUZwOj4tAmvpXjYFCqWXbNjZxEs4",
+      "dp": "669a3fzXAU4IoCdgK5R5n35qGbNfex0zmYl9x2e01I7CoFEpFUT-vWDkUq5IPd2snz4LdjaUxzEvxFJJCkZvqCv1A7cfcX2AFy-cnGhNWzMOLPIUeah2O2uKNmxLkC_0YAaKiq4o7rPibzfR8WsNH2Ok_u1dF46ofrcJnXBMyks",
+      "dq": "FhPBDu9THYqwJTIic1epGUWS7lus7e2SsgdrTXCAgegq7L2W6uKwLDxUlh3GCoIXyakm0ks1SROpfkv8u-E-_LvtuIzviFaCuxAMDrQNNYPkqdAkP-4KFchAVYVyYQr3pAyeQbbrpa06lAhj64XqmhEUgnsfINYgR6iN81m1Dmk",
+      "n": "0PPC0byb9f-Kueq8B733sZnANXDHyy2M5qUr1vWW733l_lOf2dFKDu6csaGEALro_39EFjhoad1D7Ebw1srj5APElaX9QMQxjK4pEdJlNU9SygwBObgAqCxfWmBjNBQ4NBrG8wi61MG4aoYwi-5W-N0VLL6tOxe_V6JyA4P4e-EzrlRJm9_dHT6ev3c6KyaRcGVnOBuArj3uhOh15-tbjuux8P30kR6RytxRWRZzAQqpkekpBFYYvoFyP3N_WGU5ruOEUYF8KloDmFqANSpqXvUyI3kl-McTtqzH0BuZG6fG8bH3ZZdH1fM2BJ8z0fO7n24HhNn3lAIPo8q9OPlA2Q"
+    },
+    {
+      "p": "xMkiP2irzMOFmQCYOWbnBOHg5wFPxFypGBAk8jmGCxe7njvjZPZ4k5xQf6XMBZkFANCro920ApwvdC9DweMyMOblFa7wRWBkOEgvxV9sFXRBOnvYQeVXB-tWp6p3DUqXC1APRrRkGnJAOEWhgtQrDLTDrxXz7m0NBC7xDeruSy0",
+      "kty": "RSA",
+      "q": "sqPpmS2vApCSSua3rdAAaNzyqGP3wGvigungzZpX40_JlSlfIiYE6KLPuCZnuFIjCcG2dxZ7FnZhbupDpb4f720bYdGoFQs1j4z8Pm6VHJlZJ2anq4T2ZS9gOiUd51eQWT-G1vmvgs-8XBb80gePsE_MEvZbbaGuts3UC_nWpPk",
+      "d": "MhekjcELeJ9CayS_MZhD9uN751nmSJ3jgV_Us-QHV-1DornrAkhptQGQn4qfs-92uj6_4LY6M3xLl8FZHO9z-OPSfxK0tgOBECpgiWwm_qSl825S68OYYnRPE84NAKNklvmv5ihFTZRtgIJNvFsIdKS5ZUY31zhNNjs9P4txxYZ0G_Q--l7koie4CXI8Boy7ZxbiCxzh04K40QWW1Ui378PyScQo65aqv9oDibrCpgQHW3eWq0rG0e3PyngBW8j6xDqYHTa5cto5oLtizV-0sRK--cTyIyD7DJbFwCOKyis1Lqq8OTTMvqyaSXPEJY3u8vEVdzM8rjqg61EeMs8j4Q",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "initialkey-3",
+      "qi": "fLmBa9vAltNdT1Tdo9r24tStgsosNln8b0XQtNA-v5aSSZrGYQGUst5iC70J_qT0sLVALnJJoS0JeSkjBiC_PnnmtZbTOGkzgKsuimhNsIWUILrFiDgaR7ujEiNuDc-pucVPRQ2xLstvCmPR1ocSYpACR0dKZEgOfh3ghPL61zo",
+      "dp": "Y7WiU8y-mD9N10vU1ekND41APuyMNWvaBiZQAighgkdhOnkP7F1ylSC0LSmeKgvx3ArfnWU9y8DFzrIQPBLZoKut0gHVHuILhfUVt4V1J53DW1XbKvCA27NkMgqOzj5IMGQ9iU7oFfpkDd9CSh8lPQfuyy1tbxb0bHU4kRvD6HU",
+      "dq": "F3rf61hL1oR2Fg45OklKpH3WDzgEinAjt51SBPQydRg5oLdtX6mrn4A22TeDDoENRe0GNKTpzMwGhnOYLKLOw8ONg8_wzcNJaPLY_MPAKaAmTb16cFrrn-UYOsxCH_Qsbu6gpITxArqXQWtsE5cW1c_HPP7QiZpkwnZPVruh8NE",
+      "n": "iVHZcbSmKmmCCJQ52WFtyB5w6nE-34Ykds-GZSg47JI52Gr4wLKnpAfQH_zob_SikXQ9B98ivrI8-QoAAMbsrOnGJIcXgxoxZ2cYUOsR7Ft_M_22VCvyqH1YP0ahA-mnjfYHg_VfKW1PTdBqYcYT2XaX4nD7qDzIvarzQUYOYXlMMNaNAUj4Whq4IV_qvDJU7sUYRyrPOFKvLiH5d-EHPeV9Nut01Gt6Ux2OSOQheE7UizKNQx5cvrTXlKur5zS0xxCbkLsIh81xINYAfkmwwqwKZ5R0NdrqPvsjt_k3IMRjkE2OZ3eeBermYwtAJvSDpyIZn1ntYgvOwQpKxo3yxQ"
+    },
+    {
+      "p": "4xriuf47Gk2xcOlFKftdFlcnpZ-NwETqqhW2pQpOLvYhaInGBKiK5WLjGy29YoAh2kWOBj1zW4Ug19ohYGmh3yu3Q3a3Lem6uJrN0NOkt0w0zfwta6UKaPXJ2jDMCHOyShBmeBSJcrCIy6DAA9bhuU7z31zd2K4MgMv59kyOo3E",
+      "kty": "RSA",
+      "q": "v9iN0HnKObqTLZbY3S9fM9u4lLG5Q4zCmYvleTreZ8LFb38xDAAEzYNu09nYPPGxUDSD9vHUbYoU9zKTRiWXlf-qJw9fiEsTpWFZPRc6AYqosdVSRjoClAgczoOUY_2U8PCyUIpTzn4mquC8h5D6ZXczPaukAudB0VM2EQEqf0U",
+      "d": "KKGAiF0lQJnAPD5O7-l2BnVHJR_95m2QbSxmyIalA8jVwxtXMMlZdymla1K5b8NflgYlJKB1MeHtGZMtdg_U8MCfuQXAaQc3IQg8oUQ3dwHBJrFYXsoS2P7S6XQ-geHAhzlMtYJDKc28SudRnGJP-ZkiTLWVQpSbRoAGnCz36mK8j1MlD6d_14UhyU_hqFCCEcMhQzFm4FZRN8U2sj0d0Dppm2pko_D6xswZxcRL9kjUNAKR-sdWcLGdCqutrvwmtO9r9wNJa3STVcn7Ya_--rrX2JPYFKEKwWDH6r0ZX4NIeI8Gdiu9j5iztppVMsqmg-lpcU-Tc4rgJKhhalEEgQ",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "initialkey-4",
+      "qi": "1vc5qZgIg3ptsg8WmyUHmpVCtY_PG8rnZSd0dIuC9u_c841FtRNMbUCNiTujthYmtlcaf6qIQiqmHBPWuEI00ywLcyUX-WDEzEkHUKqpuLGVM65MxlGV0LOO8hgdeGXfyrUYJ2ACG0yD5G6uj9I9Sl_aAyf0MQFfEaRTfE7CtLQ",
+      "dp": "bukEbR0RtCjZTXE-y9_seCqcPDCNw6ZkjCgKiNNdl2WwryMJx-Cf5KLEktNluCMnZTeuwrFkEwATKBdpUXKFET6CQ7pIf220OM-xUBjsSnA3IZnUfMufJ99RcvN90WrfWXhk8qPk9FPumrOo0rcwiZVbWGw8E8P8azIyouyEhKE",
+      "dq": "e9kNE_zLtCDiSpgLQB8I0q2Rp0xkUVtZdU5-wZhjY5C1bJkrzJdmglXLAjCsDAvrb9-3IYBUprJxfnPD55D1HvyBl92wyofNEwKZXXrVE5Gz_bm892ETsQTbs-X1sedOc4yvUJc8Kx39UGrsyoepXj9pcPKRWt53-u5BBRE_ohE",
+      "n": "qjErptJgXjqW9K-27k2FrSGiQJVFYbzlovJJtayk-ANMNpoJbTV5pMA6_ArxN3r_unUB6R6Psl0_LpIhM9LCUyUExZybnY9d0uVbbDtwVC-mFOs0dXQqEV7_DjicpuWQ0ds3lB_zG5nesokwAFNzvk7tvMhvIilkvh14Q5nWTI78rmMY_rjYDsNp0nIL4eUBOoUscqJQ6Z4bDhB1sygS3dFwjxFxCUEsRPjmpm2Qbw5nhVcJWO1KawB_PYqr54LaRY_VX_P3RhWWaDqTuHb_b9jcpZxfL3jWJ79Yjjyw2IAjJVjGnHqN-Yu_7Vh6vB8pDv7Jb2iCVJVLRl3opxEcdQ"
+    },
+    {
+      "p": "3rAPTm2gdVCEvFG9lPT2CEZhwjpESbuSbmIuL1sMazR9Y8imX3JPE4vFiBRxE63Ol0R_p_sQ4W9oO7HSdj-027GxARVdIwVx_0UboTY_ljfuMq2y5yKyXXym-DmppMAh1KS-xRLqblbGX6QmN8PmhSH2r62kLHcrL0HTZNhqchM",
+      "kty": "RSA",
+      "q": "y2HAJ4E60bF-S-eh-oFEWtLRiVK9YtBjtz4Syfa0svcRjgXTaH7ebqBO1qG3qHU43Kn9ps4TJTZx8qt7OXQTbQalfVX6Dd7HdeYOal6hcNFKIKsvd1epFZcmlKvilItTgu_m_GvfxXj7zLqVk_wHY14E2V0E6cFD9n6rqX7WP8M",
+      "d": "eU3pdM0zBkvLf8NCmZebg7q15564pHpeF85MOwNk302g7uIeY8WxfOiL9Mj8Z6qTFuOIFD7E9UWor5fOG2z2Pz54PTRMabb1dXO90rCt6JMkPB86e7WGx_VSjV_ibKfpjZ6y3LgCprSzZnnr3FUMWgcZlBJ92cRheZEcEi0XNFJNTF2M0YdoHfhoayzrTJaF6qgwfjhqJTUFvaP_cSrPAdhNFJ7hM_yzoOlpq33V6GbylvJ2C2GpAWd8khu5DyOmySNt79HYCzSdhCJY-oN2GFewZhRUk8vT8AsGZNONFCJtHtaqs6kIhrtQhJNE6i3pfJHLwOq5CJHVun2RmHbrIQ",
+      "e": "AQAB",
+      "use": "sig",
+      "kid": "initialkey-5",
+      "qi": "DY7KQvVnUgQJqIkTSObp6P4DMfHeiom_U4vgwKoFDNzYgMvLh_VvfPdhqzSS6IlPD0_Gyc7hwK5SpitLp-WmtNnsqfFKy0VQMFkiBfdJEPWIDMMUrZZ6nsl9KjV7MiDrkYonw71eSFNh2NEX30DWKTTk9KojpcU0HvM_912rH8o",
+      "dp": "fmNWjKDTzUGh1HBgNUbCzPeFTINddquq9FNs-xul9MKZ2CRtqQZrsyBFQHK5qv2en2QVP_XTIt_kPN00IkEOGRLE72R8s__HL6a9g8YSWOPtoX3MaDrdGQpCiefQTN1vVg0a6SdPPsipVmcH-eaJ003vgM4Au-v26p9lp3rdD1k",
+      "dq": "dOYRkWNZEJApnK1dz-OfC2kjYP_6tSI8PmXiXM19nWQfZfd5RRWu-f0Qc5NuQdhmv4bBsa-_F2OM6UOhRyutwrvQQRM679_924lI_eC4gGT7a32ZgcoT-MHxPgDx8hmG_bqwlKPYceORL2KLeQyinn264cjyev1H-BVky76InQs",
+      "n": "sOqj_2Zc0AB3St_KkSwChpNbNfFTd76_-mtPCT_xP68O-YAB20n_7HWi6zMwRMStA7q3_R9FnhJ-AHVj92dUhZB5BmgPHrEadYwS0F1XyVCbC4zprz1QVgZwxSzkIiZRtB4VNlfGkSfYaaE3Iw2V5Ns9owCx0OMfkoqVO_wK8kBLfe7HMI43xUMaSuekNRxGkxruEMWPuqwOq7-0NciX4meykz_jHybl1UlAtHhRhlI25LgsumsDP0N-3FNDv8uwwGrcalYwAj1tScpdawUgiN2WjxnZn_WtTMRVy2XzbNEvTHoOqygRLCmsBxErCNJDtiU9N__3M7XqzSO-wQmReQ"
+    }
+  ]
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyProviderTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyProviderTest.kt
@@ -1,0 +1,86 @@
+package no.nav.security.mock.oauth2.token
+
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.RSAKey
+import io.kotest.assertions.asClue
+import io.kotest.matchers.collections.shouldBeIn
+import io.kotest.matchers.collections.shouldNotBeIn
+import io.kotest.matchers.shouldBe
+import no.nav.security.mock.oauth2.token.KeyProvider.Companion.INITIAL_KEYS_FILE
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+
+internal class KeyProviderTest {
+
+    private val initialKeysFile = File("src/main/resources$INITIAL_KEYS_FILE")
+
+    @Test
+    fun `signingKey should return a key from initial keys file until deque is empty`() {
+        val provider = KeyProvider()
+        val initialPublicKeys = initialPublicKeys()
+
+        for (i in initialPublicKeys.indices) {
+            provider.signingKey("issuer$i").asClue {
+                it.toRSAPublicKey() shouldBeIn initialPublicKeys
+                it.keyID shouldBe "issuer$i"
+            }
+        }
+
+        provider.signingKey("shouldBeGeneratedOnTheFly").asClue {
+            it.toRSAPublicKey() shouldNotBeIn initialPublicKeys
+            it.keyID shouldBe "shouldBeGeneratedOnTheFly"
+        }
+    }
+
+    @Test
+    fun `signingKey should return a key from provided constructor arg until deque is empty`() {
+        val initialKeys = generateKeys(2)
+        val provider = KeyProvider(initialKeys)
+        val initialPublicKeys = initialKeys.map { it.toRSAPublicKey() }
+
+        for (i in initialPublicKeys.indices) {
+            provider.signingKey("issuer$i").asClue {
+                it.toRSAPublicKey() shouldBeIn initialPublicKeys
+                it.keyID shouldBe "issuer$i"
+            }
+        }
+
+        provider.signingKey("shouldBeGeneratedOnTheFly").asClue {
+            it.toRSAPublicKey() shouldNotBeIn initialPublicKeys
+            it.keyID shouldBe "shouldBeGeneratedOnTheFly"
+        }
+    }
+
+    private fun initialPublicKeys(): List<RSAPublicKey> =
+        initialKeysFile.readText().let {
+            JWKSet.parse(it).keys
+        }.map {
+            it.toRSAKey().toRSAPublicKey()
+        }
+
+    private fun writeInitialKeysFile() {
+        val list = generateKeys(5)
+        initialKeysFile.writeText(JWKSet(list).toString(false))
+    }
+
+    private fun generateKeys(numKeys: Int): List<RSAKey> {
+        val list = mutableListOf<RSAKey>()
+        for (i in 1..numKeys) {
+            val key = KeyPairGenerator.getInstance("RSA").apply { this.initialize(2048) }
+                .generateKeyPair()
+                .let {
+                    RSAKey.Builder(it.public as RSAPublicKey)
+                        .privateKey(it.private as RSAPrivateKey)
+                        .keyUse(KeyUse.SIGNATURE)
+                        .keyID("initialkey-$i")
+                        .build()
+                }
+            list.add(key)
+        }
+        return list
+    }
+}


### PR DESCRIPTION
generation of keys on endpoint access can sometimes lead to read/connect timeout for clients depending on machine hardware/os. This PR will load some RSA keys from file on startup to remediate this.

* move logic for key generation and caching into KeyProvider.kt
* allow users to bring their own keys by creating a KeyProvider in the TokenProvider constructor
* load up to 5 keys from file, new keys will be generated and cached on the fly if keys all keys are in use, i.e. if number of issuers > 5

fix #76 