### PR TITLE
feat: allow custom claims in login form

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -23,6 +23,7 @@ import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.HttpUrl
 
 private val log = KotlinLogging.logger {}
+private val jsonMapper: ObjectMapper = jacksonObjectMapper()
 
 internal class AuthorizationCodeHandler(
     private val tokenProvider: OAuth2TokenProvider,
@@ -95,8 +96,6 @@ internal class AuthorizationCodeHandler(
     private fun takeAuthenticationRequestFromCache(code: AuthorizationCode): AuthenticationRequest? = codeToAuthRequestCache.remove(code)
 
     private class LoginOAuth2TokenCallback(val login: Login, val OAuth2TokenCallback: OAuth2TokenCallback) : OAuth2TokenCallback {
-        private val jsonMapper: ObjectMapper = jacksonObjectMapper()
-
         override fun issuerId(): String = OAuth2TokenCallback.issuerId()
         override fun subject(tokenRequest: TokenRequest): String = login.username
         override fun typeHeader(tokenRequest: TokenRequest): String = OAuth2TokenCallback.typeHeader(tokenRequest)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
@@ -10,11 +10,11 @@ class LoginRequestHandler(private val templateMapper: TemplateMapper) {
     fun loginSubmit(httpRequest: OAuth2HttpRequest): Login {
         val formParameters = httpRequest.formParameters
         val username = checkNotNull(formParameters.get("username"))
-        return Login(username, formParameters.get("acr"))
+        return Login(username, formParameters.get("claims"))
     }
 }
 
 data class Login(
     val username: String,
-    val acr: String? = null
+    val claims: String? = null
 )

--- a/src/main/resources/templates/css/custom.css
+++ b/src/main/resources/templates/css/custom.css
@@ -116,3 +116,7 @@ pre > code {
     }
 }
 
+.claims {
+    resize: vertical;
+    height: fit-content;
+}

--- a/src/main/resources/templates/login.ftl
+++ b/src/main/resources/templates/login.ftl
@@ -16,9 +16,11 @@
                                autofocus="on">
                     </label>
                     <label>
-                        <input class="u-full-width" required type="text" name="acr"
-                               placeholder="Optional 'acr' claim value"
-                               autofocus="on">
+                        <textarea class="u-full-width claims" name="claims" rows="15"
+                               placeholder="Optional claims JSON value, example:
+{
+  &quot;acr&quot;: &quot;reference&quot;
+}" autofocus="on"></textarea>
                     </label>
                     <input class="button-primary" type="submit" value="Sign-in">
                 </form>

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
@@ -1,13 +1,16 @@
 package no.nav.security.mock.oauth2.grant
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.ResponseMode
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.login.Login
 import no.nav.security.mock.oauth2.testutils.authenticationRequest
+import no.nav.security.mock.oauth2.testutils.claims
 import no.nav.security.mock.oauth2.testutils.subject
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
@@ -15,6 +18,11 @@ import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
+import java.util.stream.Stream
 
 internal class AuthorizationCodeHandlerTest {
     private val handler = AuthorizationCodeHandler(OAuth2TokenProvider(), RefreshTokenManager())
@@ -46,6 +54,56 @@ internal class AuthorizationCodeHandlerTest {
 
         handler.tokenResponse(tokenRequest(code = code), "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).asClue {
             SignedJWT.parse(it.idToken).subject shouldBe "foo"
+        }
+    }
+
+    @ParameterizedTest
+    @MethodSource("jsonClaimsProvider")
+    fun `token response with login including claims should return access_token containing claims from login`(claims: String, expectedClaimKey: String, expectedClaimValue: String) {
+        val code: String = handler.authorizationCodeResponse(
+            authenticationRequest = "http://authorizationendpoint".toHttpUrl().authenticationRequest().asNimbusAuthRequest(),
+            login = Login("foo", claims)
+        ).authorizationCode.value
+
+        handler.tokenResponse(tokenRequest(code = code), "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).asClue {
+            val claim = SignedJWT.parse(it.idToken).claims[expectedClaimKey]
+            claim shouldNotBe null
+            jacksonObjectMapper().writeValueAsString(claim) shouldBe expectedClaimValue
+        }
+    }
+
+    companion object {
+        @JvmStatic
+        fun jsonClaimsProvider(): Stream<Arguments> = Stream.of(
+            Arguments.of("{ \"acr\": \"value\" }", "acr", "\"value\""),
+            Arguments.of("{ \"acr\": { \"reference\": { \"id\": \"value\" } } }", "acr", "{\"reference\":{\"id\":\"value\"}}")
+        )
+    }
+
+    @Test
+    fun `token response with login including multiple claims should return access_token containing all claims from login`() {
+        val code: String = handler.authorizationCodeResponse(
+            authenticationRequest = "http://authorizationendpoint".toHttpUrl().authenticationRequest().asNimbusAuthRequest(),
+            login = Login("foo", "{ \"acr\": \"value1\", \"abc\": \"value2\" }")
+        ).authorizationCode.value
+
+        handler.tokenResponse(tokenRequest(code = code), "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).asClue {
+            val claims = SignedJWT.parse(it.idToken).claims
+            claims["acr"] shouldBe "value1"
+            claims["abc"] shouldBe "value2"
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["{", "[]", "[\"claim\"]", "{}"])
+    fun `token response with login including invalid JSON for claims parsing should return access_token containing no additional claims`(claimsValue: String) {
+        val code: String = handler.authorizationCodeResponse(
+            authenticationRequest = "http://authorizationendpoint".toHttpUrl().authenticationRequest().asNimbusAuthRequest(),
+            login = Login("foo", claimsValue)
+        ).authorizationCode.value
+
+        handler.tokenResponse(tokenRequest(code = code), "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).asClue {
+            SignedJWT.parse(it.idToken).claims.count() shouldBe 10
         }
     }
 


### PR DESCRIPTION
Replace the acr field in the login form with a text area that is supposed to be filled with a JSON structure containing one or more claims.

This implements https://github.com/navikt/mock-oauth2-server/issues/112