### PR TITLE
feat: add login form header and footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Example:
 ```json
 {
     "interactiveLogin": true,
+    "loginHeader": [ "<b>login form header<b>" ],
+    "loginFooter": [ "<b>login form footer<b>" ],
     "httpServer": "NettyWrapper",
     "tokenCallbacks": [
         {
@@ -258,6 +260,8 @@ Example:
 | Property | Description |
 | --- | --- |
 | `interactiveLogin` | `true` or `false`, enables login screen when redirecting to server `/authorize` endpoint |
+| `loginHeader` | A list of strings containing text or html that will be shown above the login form |
+| `loginFooter` | A list of strings containing text or html that will be shown below the login form |
 | `httpServer`| A string identifying the httpserver to use. Must match one of the following enum values: `MockWebServerWrapper` or `NettyWrapper`|
 | `tokenCallbacks` | A list of [`RequestMappingTokenCallback`](src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt) that lets you specify which token claims to return when a token request matches the specified condition.|
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
@@ -19,6 +19,8 @@ import java.io.File
 
 data class OAuth2Config @JvmOverloads constructor(
     val interactiveLogin: Boolean = false,
+    val loginHeader: List<String> = listOf(),
+    val loginFooter: List<String> = listOf(),
     @JsonDeserialize(using = OAuth2TokenProviderDeserializer::class)
     val tokenProvider: OAuth2TokenProvider = OAuth2TokenProvider(),
     @JsonDeserialize(contentAs = RequestMappingTokenCallback::class)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -106,7 +106,10 @@ class OAuth2HttpRequestHandler(
         return when (request.method) {
             "GET" -> {
                 if (config.interactiveLogin || authRequest.isPrompt())
-                    html(loginRequestHandler.loginHtml(request))
+                    html(loginRequestHandler.loginHtml(
+                        request,
+                        config.loginHeader.joinToString(System.lineSeparator()),
+                        config.loginFooter.joinToString(System.lineSeparator())))
                 else {
                     authenticationSuccess(authorizationCodeHandler.authorizationCodeResponse(authRequest))
                 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
@@ -5,7 +5,7 @@ import no.nav.security.mock.oauth2.templates.TemplateMapper
 
 class LoginRequestHandler(private val templateMapper: TemplateMapper) {
 
-    fun loginHtml(httpRequest: OAuth2HttpRequest): String = templateMapper.loginHtml(httpRequest)
+    fun loginHtml(httpRequest: OAuth2HttpRequest, header: String, footer: String): String = templateMapper.loginHtml(httpRequest, header, footer)
 
     fun loginSubmit(httpRequest: OAuth2HttpRequest): Login {
         val formParameters = httpRequest.formParameters

--- a/src/main/kotlin/no/nav/security/mock/oauth2/templates/TemplateMapper.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/templates/TemplateMapper.kt
@@ -15,13 +15,15 @@ class TemplateMapper(
     private val config: Configuration
 ) {
 
-    fun loginHtml(oAuth2HttpRequest: OAuth2HttpRequest): String =
+    fun loginHtml(oAuth2HttpRequest: OAuth2HttpRequest, header: String, footer: String): String =
         asString(
             HtmlContent(
                 "login.ftl",
                 mapOf(
                     "request_url" to oAuth2HttpRequest.url.newBuilder().query(null).build().toString(),
-                    "query" to OAuth2HttpRequest.Parameters(oAuth2HttpRequest.url.query).map
+                    "query" to OAuth2HttpRequest.Parameters(oAuth2HttpRequest.url.query).map,
+                    "header" to header,
+                    "footer" to footer
                 )
             )
         )

--- a/src/main/resources/templates/login.ftl
+++ b/src/main/resources/templates/login.ftl
@@ -12,12 +12,12 @@
             <div class="six columns">
                 <form method="post">
                     <label>
-                        <input class="u-full-width" required type="text" name="username"
+                        <input class="u-full-width" required type="text" id="username" name="username"
                                placeholder="Enter any user/subject"
                                autofocus="on">
                     </label>
                     <label>
-                        <textarea class="u-full-width claims" name="claims" rows="15"
+                        <textarea class="u-full-width claims" id="claims" name="claims" rows="15"
                                placeholder="Optional claims JSON value, example:
 {
   &quot;acr&quot;: &quot;reference&quot;

--- a/src/main/resources/templates/login.ftl
+++ b/src/main/resources/templates/login.ftl
@@ -5,6 +5,7 @@
     <section class="header">
         <h2 class="title">Mock OAuth2 Server Sign-in</h2>
     </section>
+    <div>${header}</div>
     <div class="docs-section" id="sign-in">
         <div class="row">
             <div class="three columns">&nbsp;</div>
@@ -28,6 +29,7 @@
             <div class="three columns">&nbsp;</div>
         </div>
     </div>
+    <div>${footer}</div>
     <div class="docs-section">
 
         <div class="row">

--- a/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
@@ -42,6 +42,8 @@ internal class OAuth2ConfigTest {
     fun `create full config from json with multiple tokenCallbacks`() {
         val config = OAuth2Config.fromJson(configJson)
         config.interactiveLogin shouldBe true
+        config.loginHeader shouldBe listOf("headerLine1", "headerLine2")
+        config.loginFooter shouldBe listOf("footerLine1", "footerLine2")
         config.httpServer should beInstanceOf<NettyWrapper>()
         config.tokenCallbacks.size shouldBe 2
         config.tokenCallbacks.map {
@@ -105,6 +107,8 @@ object FullConfig {
     @Language("json")
     val configJson = """{
       "interactiveLogin" : true,
+      "loginHeader": [ "headerLine1", "headerLine2" ],
+      "loginFooter": [ "footerLine1", "footerLine2" ],
       "httpServer": "NettyWrapper",
       "tokenCallbacks": [
         {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2ServerKtTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2ServerKtTest.kt
@@ -26,6 +26,8 @@ internal class StandaloneMockOAuth2ServerKtTest {
         val config = oauth2Config()
         config.tokenCallbacks.size shouldBe 0
         config.interactiveLogin shouldBe true
+        config.loginHeader shouldBe listOf()
+        config.loginFooter shouldBe listOf()
         config.httpServer should beInstanceOf<NettyWrapper>()
         hostname() shouldBe InetSocketAddress(0).address
         port() shouldBe 8080


### PR DESCRIPTION
This PR adds two new optional configuration elements (string arrays) that can be used to "inject" html into the login form.
This makes it possible to add some simple instructions or even some additional elements (e.g. a button to prefill the form) to the login form.

Please let me know what you think.