### PR TITLE
feat: Add configurable presets

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -128,16 +128,17 @@ open class MockOAuth2Server(
     fun issueTokenWithClaimsFromPreset(
         presetName: String,
         issuerId: String = "default",
-        subject: String = UUID.randomUUID().toString(),
         audience: String? = "default",
         expiry: Long = 3600
-    ): SignedJWT = issueToken(
-        issuerId,
-        subject,
-        audience,
-        config.presetWithName(presetName).claims,
-        expiry
-    )
+    ): SignedJWT = config.presetWithName(presetName).let { preset ->
+        issueToken(
+            issuerId,
+            preset.username,
+            audience,
+            preset.claims,
+            expiry
+        )
+    }
 
     @JvmOverloads
     fun anyToken(issuerUrl: HttpUrl, claims: Map<String, Any>, expiry: Duration = Duration.ofHours(1)): SignedJWT {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -125,6 +125,21 @@ open class MockOAuth2Server(
     )
 
     @JvmOverloads
+    fun issueTokenWithClaimsFromPreset(
+        presetName: String,
+        issuerId: String = "default",
+        subject: String = UUID.randomUUID().toString(),
+        audience: String? = "default",
+        expiry: Long = 3600
+    ): SignedJWT = issueToken(
+        issuerId,
+        subject,
+        audience,
+        config.presetWithName(presetName).claims,
+        expiry
+    )
+
+    @JvmOverloads
     fun anyToken(issuerUrl: HttpUrl, claims: Map<String, Any>, expiry: Duration = Duration.ofHours(1)): SignedJWT {
         val jwtClaimsSet = claims.toJwtClaimsSet()
         val mockGrant: AuthorizationGrant = object : AuthorizationGrant(GrantType("MockGrant")) {
@@ -140,6 +155,10 @@ open class MockOAuth2Server(
             )
         )
     }
+
+    @JvmOverloads
+    fun anyTokenWithClaimsFromPreset(presetName: String, issuerUrl: HttpUrl, expiry: Duration = Duration.ofHours(1)): SignedJWT =
+        anyToken(issuerUrl, config.presetWithName(presetName).claims, expiry)
 }
 
 internal fun Map<String, Any>.toJwtClaimsSet(): JWTClaimsSet =

--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -171,9 +171,10 @@ internal fun Map<String, Any>.toJwtClaimsSet(): JWTClaimsSet =
         }.build()
 
 fun <R> withMockOAuth2Server(
+    config: OAuth2Config = OAuth2Config(),
     test: MockOAuth2Server.() -> R
 ): R {
-    val server = MockOAuth2Server()
+    val server = MockOAuth2Server(config)
     server.start()
     try {
         return server.test()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonParser
 import com.fasterxml.jackson.databind.DeserializationContext
 import com.fasterxml.jackson.databind.JsonDeserializer
 import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
@@ -19,6 +20,7 @@ import java.io.File
 
 data class OAuth2Config @JvmOverloads constructor(
     val interactiveLogin: Boolean = false,
+    val presets: List<Preset> = emptyList(),
     @JsonDeserialize(using = OAuth2TokenProviderDeserializer::class)
     val tokenProvider: OAuth2TokenProvider = OAuth2TokenProvider(),
     @JsonDeserialize(contentAs = RequestMappingTokenCallback::class)
@@ -76,4 +78,16 @@ data class OAuth2Config @JvmOverloads constructor(
             return jacksonObjectMapper().readValue(json)
         }
     }
+
+    fun presetWithName(name: String): Preset =
+        presets.first { it.name == name }
+}
+
+data class Preset(
+    val name: String,
+    val username: String,
+    val claims: Map<String, Any>
+) {
+    val claimsAsString: String
+        get() = ObjectMapper().writerWithDefaultPrettyPrinter().writeValueAsString(claims)
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -106,7 +106,7 @@ class OAuth2HttpRequestHandler(
         return when (request.method) {
             "GET" -> {
                 if (config.interactiveLogin || authRequest.isPrompt())
-                    html(loginRequestHandler.loginHtml(request))
+                    html(loginRequestHandler.loginHtml(request, config.presets))
                 else {
                     authenticationSuccess(authorizationCodeHandler.authorizationCodeResponse(authRequest))
                 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
@@ -1,11 +1,12 @@
 package no.nav.security.mock.oauth2.login
 
+import no.nav.security.mock.oauth2.Preset
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.templates.TemplateMapper
 
 class LoginRequestHandler(private val templateMapper: TemplateMapper) {
 
-    fun loginHtml(httpRequest: OAuth2HttpRequest): String = templateMapper.loginHtml(httpRequest)
+    fun loginHtml(httpRequest: OAuth2HttpRequest, presets: List<Preset>): String = templateMapper.loginHtml(httpRequest, presets)
 
     fun loginSubmit(httpRequest: OAuth2HttpRequest): Login {
         val formParameters = httpRequest.formParameters

--- a/src/main/kotlin/no/nav/security/mock/oauth2/templates/TemplateMapper.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/templates/TemplateMapper.kt
@@ -2,6 +2,7 @@ package no.nav.security.mock.oauth2.templates
 
 import freemarker.cache.ClassTemplateLoader
 import freemarker.template.Configuration
+import no.nav.security.mock.oauth2.Preset
 import no.nav.security.mock.oauth2.extensions.toTokenEndpointUrl
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import java.io.StringWriter
@@ -15,13 +16,14 @@ class TemplateMapper(
     private val config: Configuration
 ) {
 
-    fun loginHtml(oAuth2HttpRequest: OAuth2HttpRequest): String =
+    fun loginHtml(oAuth2HttpRequest: OAuth2HttpRequest, presets: List<Preset>): String =
         asString(
             HtmlContent(
                 "login.ftl",
                 mapOf(
                     "request_url" to oAuth2HttpRequest.url.newBuilder().query(null).build().toString(),
-                    "query" to OAuth2HttpRequest.Parameters(oAuth2HttpRequest.url.query).map
+                    "query" to OAuth2HttpRequest.Parameters(oAuth2HttpRequest.url.query).map,
+                    "presets" to presets
                 )
             )
         )

--- a/src/main/resources/templates/css/custom.css
+++ b/src/main/resources/templates/css/custom.css
@@ -18,6 +18,12 @@ pre > code {
     text-align: center;
 }
 
+.presets-section {
+    margin: 0 auto;
+    width: min-content;
+    white-space: nowrap;
+}
+
 .value-prop {
     margin-top: 1rem;
 }

--- a/src/main/resources/templates/login.ftl
+++ b/src/main/resources/templates/login.ftl
@@ -5,18 +5,44 @@
     <section class="header">
         <h2 class="title">Mock OAuth2 Server Sign-in</h2>
     </section>
+    <div class="presets-section">
+        <script lang="javascript">
+            function setUsername(username) {
+                document.getElementById('username').value = username;
+            }
+
+            function setClaims(claims) {
+                document.getElementById('claims').value = claims
+            }
+
+            const presets = {
+                <#list presets as preset>
+                '${preset.name}' : {
+                    'username' : '${preset.username}',
+                    'claims' : `${preset.claimsAsString}`
+                },
+                </#list>
+            }
+        </script>
+        <div>
+            <#list presets as preset>
+                <button onClick="setUsername(presets['${preset.name}'].username); setClaims(presets['${preset.name}'].claims);">${preset.name}</button>
+            </#list>
+            <button onClick="setUsername(''); setClaims('');">Clear</button>
+        </div>
+    </div>
     <div class="docs-section" id="sign-in">
         <div class="row">
             <div class="three columns">&nbsp;</div>
             <div class="six columns">
                 <form method="post">
                     <label>
-                        <input class="u-full-width" required type="text" name="username"
+                        <input class="u-full-width" required type="text" id="username" name="username"
                                placeholder="Enter any user/subject"
                                autofocus="on">
                     </label>
                     <label>
-                        <textarea class="u-full-width claims" name="claims" rows="15"
+                        <textarea class="u-full-width claims" id="claims" name="claims" rows="15"
                                placeholder="Optional claims JSON value, example:
 {
   &quot;acr&quot;: &quot;reference&quot;


### PR DESCRIPTION
Since #113 we can enter a custom set of claims in the login form. This is already very useful! However, when using mock-oauth2-server standalone for manually testing a webapp, it would be very useful if we could configure some presets for this, which can be quickly filled in on the login form by pressing a button.

This PR adds this functionality.

Example configuration:
```json
{
  "interactiveLogin": true,
  "presets": [
    {
      "name": "Preset 1",
      "username": "username1",
      "claims": {
        "acr": "reference",
        "custom_claim": "some_value",
        "complex_claim": {
          "array_of_strings": ["one", "two"]
        }
      }
    },
    {
      "name": "Preset 2",
      "username": "username2",
      "claims": {
        "some_other_claim": "some_other_value"
      }
    }
  ]
}
```

Two new methods (`issueTokenWithClaimsFromPreset` and `anyTokenWithClaimsFromPreset`) have been added to `MockOAuth2Server`, so the presets can also be used when using mock-oauth2-server for integration testing.

The login page shows a button for each preset. Upon clicking a button, the username and claims will be filled with the values from the associated preset. A "Clear" button has also been added, so the form can easily be cleared.

![image](https://user-images.githubusercontent.com/3872163/138465918-a08c25a1-9611-4cb3-9164-ccd35c729625.png)

I'd love to get some feedback on this!

Some considerations:
- I'm not entirely sure about the name `preset`. I've also considered `user` and `profile`, but `preset` seemed like the most accurate name to me.
- I'm also not entirely sure about the usefulness and naming of the two new methods I added to `MockOAuth2Server`.