### PR TITLE
feat: allow external login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ Example:
 | Property | Description |
 | --- | --- |
 | `interactiveLogin` | `true` or `false`, enables login screen when redirecting to server `/authorize` endpoint |
+| `loginPagePath` | An optional string refering to a html file that is served as login page. This page needs to contain a form that posts a `username` and optionally a `claims` field. See `src/test/resource/login.example.html` as an example.|
 | `httpServer`| A string identifying the httpserver to use. Must match one of the following enum values: `MockWebServerWrapper` or `NettyWrapper`|
 | `tokenCallbacks` | A list of [`RequestMappingTokenCallback`](src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt) that lets you specify which token claims to return when a token request matches the specified condition.|
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
@@ -19,6 +19,7 @@ import java.io.File
 
 data class OAuth2Config @JvmOverloads constructor(
     val interactiveLogin: Boolean = false,
+    val loginPagePath: String? = null,
     @JsonDeserialize(using = OAuth2TokenProviderDeserializer::class)
     val tokenProvider: OAuth2TokenProvider = OAuth2TokenProvider(),
     @JsonDeserialize(contentAs = RequestMappingTokenCallback::class)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Exception.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Exception.kt
@@ -3,6 +3,7 @@ package no.nav.security.mock.oauth2
 import com.nimbusds.oauth2.sdk.ErrorObject
 import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.OAuth2Error
+import com.nimbusds.oauth2.sdk.http.HTTPResponse
 
 @Suppress("unused")
 class OAuth2Exception(val errorObject: ErrorObject?, msg: String, throwable: Throwable?) :
@@ -15,3 +16,4 @@ class OAuth2Exception(val errorObject: ErrorObject?, msg: String, throwable: Thr
 fun missingParameter(name: String): Nothing = throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "missing required parameter $name")
 fun invalidGrant(grantType: GrantType): Nothing = throw OAuth2Exception(OAuth2Error.INVALID_GRANT, "grant_type $grantType not supported.")
 fun invalidRequest(message: String): Nothing = throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, message)
+fun notFound(message: String): Nothing = throw OAuth2Exception(ErrorObject("not_found", "Resource not found", HTTPResponse.SC_NOT_FOUND), message)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -105,9 +105,9 @@ class OAuth2HttpRequestHandler(
         val authorizationCodeHandler = grantHandlers[AUTHORIZATION_CODE] as AuthorizationCodeHandler
         return when (request.method) {
             "GET" -> {
-                if (config.interactiveLogin || authRequest.isPrompt())
-                    html(loginRequestHandler.loginHtml(request))
-                else {
+                if (config.interactiveLogin || authRequest.isPrompt()) {
+                    html(loginRequestHandler.loginHtml(request, config))
+                } else {
                     authenticationSuccess(authorizationCodeHandler.authorizationCodeResponse(authRequest))
                 }
             }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandler.kt
@@ -1,11 +1,24 @@
 package no.nav.security.mock.oauth2.login
 
+import no.nav.security.mock.oauth2.OAuth2Config
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
+import no.nav.security.mock.oauth2.notFound
 import no.nav.security.mock.oauth2.templates.TemplateMapper
+import java.io.File
+import java.io.FileNotFoundException
 
 class LoginRequestHandler(private val templateMapper: TemplateMapper) {
 
-    fun loginHtml(httpRequest: OAuth2HttpRequest): String = templateMapper.loginHtml(httpRequest)
+    fun loginHtml(httpRequest: OAuth2HttpRequest, config: OAuth2Config): String =
+        config.loginPagePath
+            ?.let {
+                try {
+                    File(it).readText()
+                } catch (e: FileNotFoundException) {
+                    notFound("The configured loginPagePath '${config.loginPagePath}' is invalid, please ensure that it points to a valid html file")
+                }
+            }
+            ?: templateMapper.loginHtml(httpRequest)
 
     fun loginSubmit(httpRequest: OAuth2HttpRequest): Login {
         val formParameters = httpRequest.formParameters

--- a/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
@@ -42,6 +42,7 @@ internal class OAuth2ConfigTest {
     fun `create full config from json with multiple tokenCallbacks`() {
         val config = OAuth2Config.fromJson(configJson)
         config.interactiveLogin shouldBe true
+        config.loginPagePath shouldBe "./login.html"
         config.httpServer should beInstanceOf<NettyWrapper>()
         config.tokenCallbacks.size shouldBe 2
         config.tokenCallbacks.map {
@@ -105,6 +106,7 @@ object FullConfig {
     @Language("json")
     val configJson = """{
       "interactiveLogin" : true,
+      "loginPagePath": "./login.html",
       "httpServer": "NettyWrapper",
       "tokenCallbacks": [
         {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/LoginPageIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/LoginPageIntegrationTest.kt
@@ -1,0 +1,49 @@
+package no.nav.security.mock.oauth2.e2e
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.mock.oauth2.OAuth2Config
+import no.nav.security.mock.oauth2.testutils.authenticationRequest
+import no.nav.security.mock.oauth2.testutils.client
+import no.nav.security.mock.oauth2.testutils.get
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class LoginPageIntegrationTest {
+
+    private val client = client()
+
+    @Test
+    fun `authorization with interactive login should return built-in login page`() {
+        val server = MockOAuth2Server(OAuth2Config(interactiveLogin = true)).apply { start() }
+        val body = client.get(server.authorizationEndpointUrl("default").authenticationRequest()).body?.string()
+
+        body shouldNotBe null
+        body shouldContain "<h2 class=\"title\">Mock OAuth2 Server Sign-in</h2>"
+    }
+
+    @Test
+    fun `authorization with interactive login and login page path set should return external login page`() {
+        val server = MockOAuth2Server(OAuth2Config(
+            interactiveLogin = true,
+            loginPagePath = "./src/test/resources/login.example.html")).apply { start() }
+        val body = client.get(server.authorizationEndpointUrl("default").authenticationRequest()).body?.string()
+
+        body shouldNotBe null
+        body shouldContain "<h4>Mock OAuth2 Server Example Sign-in</h4>"
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["./src/test/resources/does-not-exists.html", "./src/test/resources/", ""])
+    fun `authorization with interactive login and login page path set to invalid path should return 404`(path: String) {
+        val server = MockOAuth2Server(OAuth2Config(
+            interactiveLogin = true,
+            loginPagePath = path)).apply { start() }
+        val code = client.get(server.authorizationEndpointUrl("default").authenticationRequest()).code
+
+        code shouldBe 404
+    }
+}

--- a/src/test/resources/login.example.html
+++ b/src/test/resources/login.example.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+    <title>Mock OAuth2 Server Example Sign-in</title>
+
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"
+        integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
+</head>
+
+<body>
+    <div class="container">
+        <div class="row mt-5 justify-content-md-center">
+            <div class="col-md-5">
+                <form method="post">
+                    <h4>Mock OAuth2 Server Example Sign-in</h4>
+                    <hr class="divisor">
+                    <div class="form-group">
+                        <input type="text" class="form-control" name="username" autofocus="on"
+                            placeholder="Enter any user/subject">
+                    </div>
+                    <div class="form-group">
+                        <textarea class="form-control" name="claims" rows="15" placeholder="Optional claims JSON value, example:
+{
+  &quot;acr&quot;: &quot;reference&quot;
+}"
+                        ></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-primary topBtn"><i class="fa fa-sign-in"></i>Sign-in</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>


### PR DESCRIPTION
Add optional configuration setting 'loginPagePath'. This path should point to an html file which is then served instead of the built-in login page.

Supersedes https://github.com/navikt/mock-oauth2-server/pull/114