### PR TITLE
feat: add CORS headers

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -26,6 +26,7 @@ import no.nav.security.mock.oauth2.http.RequestType.DEBUGGER_CALLBACK
 import no.nav.security.mock.oauth2.http.RequestType.END_SESSION
 import no.nav.security.mock.oauth2.http.RequestType.FAVICON
 import no.nav.security.mock.oauth2.http.RequestType.JWKS
+import no.nav.security.mock.oauth2.http.RequestType.PREFLIGHT
 import no.nav.security.mock.oauth2.http.RequestType.TOKEN
 import no.nav.security.mock.oauth2.http.RequestType.UNKNOWN
 import no.nav.security.mock.oauth2.http.RequestType.WELL_KNOWN
@@ -84,6 +85,7 @@ data class OAuth2HttpRequest(
         url.isDebuggerUrl() -> DEBUGGER
         url.isDebuggerCallbackUrl() -> DEBUGGER_CALLBACK
         url.encodedPath == "/favicon.ico" -> FAVICON
+        method == "OPTIONS" -> PREFLIGHT
         else -> UNKNOWN
     }
 
@@ -128,5 +130,5 @@ data class OAuth2HttpRequest(
 
 enum class RequestType {
     WELL_KNOWN, AUTHORIZATION, TOKEN, END_SESSION, JWKS,
-    DEBUGGER, DEBUGGER_CALLBACK, FAVICON, UNKNOWN
+    DEBUGGER, DEBUGGER_CALLBACK, FAVICON, PREFLIGHT, UNKNOWN
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -10,6 +10,7 @@ import com.nimbusds.oauth2.sdk.GrantType.REFRESH_TOKEN
 import com.nimbusds.oauth2.sdk.OAuth2Error
 import com.nimbusds.oauth2.sdk.ParseException
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
+import io.netty.handler.codec.http.HttpHeaderNames
 import java.net.URLEncoder
 import java.nio.charset.Charset
 import java.util.concurrent.BlockingQueue
@@ -35,6 +36,7 @@ import no.nav.security.mock.oauth2.http.RequestType.DEBUGGER_CALLBACK
 import no.nav.security.mock.oauth2.http.RequestType.END_SESSION
 import no.nav.security.mock.oauth2.http.RequestType.FAVICON
 import no.nav.security.mock.oauth2.http.RequestType.JWKS
+import no.nav.security.mock.oauth2.http.RequestType.PREFLIGHT
 import no.nav.security.mock.oauth2.http.RequestType.TOKEN
 import no.nav.security.mock.oauth2.http.RequestType.WELL_KNOWN
 import no.nav.security.mock.oauth2.invalidGrant
@@ -43,6 +45,7 @@ import no.nav.security.mock.oauth2.login.Login
 import no.nav.security.mock.oauth2.login.LoginRequestHandler
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
+import okhttp3.Headers
 
 private val log = KotlinLogging.logger {}
 
@@ -74,6 +77,11 @@ class OAuth2HttpRequestHandler(
                 DEBUGGER -> debuggerRequestHandler.handleDebuggerForm(request).also { log.debug("handle debugger request") }
                 DEBUGGER_CALLBACK -> debuggerRequestHandler.handleDebuggerCallback(request).also { log.debug("handle debugger callback request") }
                 FAVICON -> OAuth2HttpResponse(status = 200)
+                PREFLIGHT -> OAuth2HttpResponse(status = 200, headers = Headers.headersOf(
+                    HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString(), "*",
+                    HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString(), "*",
+                    HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString(), "*"
+                ))
                 else -> notFound().also { log.error("path '${request.url}' not found") }
             }
         }.fold(

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
@@ -46,6 +46,9 @@ fun post(path: String, requestHandler: RequestHandler): Route =
 fun get(path: String, requestHandler: RequestHandler): Route =
     routeFromPathAndMethod(path, "GET", requestHandler)
 
+fun options(path: String, requestHandler: RequestHandler): Route =
+    routeFromPathAndMethod(path, "OPTIONS", requestHandler)
+
 private fun routeFromPathAndMethod(path: String, method: String? = null, requestHandler: RequestHandler): Route =
     object : Route {
         override fun match(request: OAuth2HttpRequest): Boolean =

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
@@ -1,0 +1,71 @@
+package no.nav.security.mock.oauth2.e2e
+
+import com.nimbusds.oauth2.sdk.GrantType
+import io.kotest.assertions.asClue
+import io.kotest.matchers.shouldBe
+import io.netty.handler.codec.http.HttpHeaderNames
+import no.nav.security.mock.oauth2.testutils.client
+import no.nav.security.mock.oauth2.testutils.get
+import no.nav.security.mock.oauth2.testutils.options
+import no.nav.security.mock.oauth2.testutils.tokenRequest
+import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
+import no.nav.security.mock.oauth2.withMockOAuth2Server
+import org.junit.jupiter.api.Test
+
+class CorsHeadersIntegrationTest {
+    private val client = client()
+
+    @Test
+    fun `preflight response should allow all origin, all methods and all headers`() {
+        withMockOAuth2Server {
+            client.options(this.baseUrl()).asClue {
+                it.code shouldBe 200
+                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
+                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString()] shouldBe "*"
+                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString()] shouldBe "*"
+            }
+        }
+    }
+
+    @Test
+    fun `wellknown response should allow all origins`() {
+        withMockOAuth2Server {
+            client.get(this.wellKnownUrl("issuer")).asClue {
+                it.code shouldBe 200
+                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
+            }
+        }
+    }
+
+    @Test
+    fun `jwks response should allow all origins`() {
+        withMockOAuth2Server {
+            client.get(this.jwksUrl("issuer")).asClue {
+                it.code shouldBe 200
+                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
+            }
+        }
+    }
+
+    @Test
+    fun `token response should allow all origins`() {
+        withMockOAuth2Server {
+            val expectedSubject = "expectedSub"
+            val issuerId = "idprovider"
+            this.enqueueCallback(DefaultOAuth2TokenCallback(issuerId = issuerId, subject = expectedSubject))
+
+            val response = client.tokenRequest(
+                this.tokenEndpointUrl(issuerId),
+                mapOf(
+                    "grant_type" to GrantType.REFRESH_TOKEN.value,
+                    "refresh_token" to "canbewhatever",
+                    "client_id" to "id",
+                    "client_secret" to "secret"
+                )
+            )
+
+            response.code shouldBe 200
+            response.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouterTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouterTest.kt
@@ -14,16 +14,21 @@ internal class OAuth2HttpRouterTest {
             get("/shouldmatch") {
                 OAuth2HttpResponse(status = 200, body = "GET")
             },
+            options("/shouldmatch") {
+                OAuth2HttpResponse(status = 200, body = "OPTIONS")
+            },
             route("shouldmatch") {
                 OAuth2HttpResponse(status = 200, body = "ANY")
             }
         )
         routes.invoke(post("http://localhost:1234/something/shouldmatch")).body shouldBe "ANY"
+        routes.invoke(options("http://localhost:1234/something/shouldmatch")).body shouldBe "OPTIONS"
         routes.invoke(get("http://localhost:1234/something/shouldmatch")).body shouldBe "GET"
     }
 
     private fun get(url: String) = request(url, "GET")
     private fun post(url: String, body: String? = "na") = request(url, "POST", body)
+    private fun options(url: String, body: String? = "na") = request(url, "OPTIONS", body)
 
     private fun request(url: String, method: String, body: String? = null) =
         OAuth2HttpRequest(

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Http.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Http.kt
@@ -95,6 +95,15 @@ fun OkHttpClient.get(
         )
     ).execute()
 
+fun OkHttpClient.options(
+    url: HttpUrl
+): Response =
+    this.newCall(
+        Request.Builder().options(
+            url
+        )
+    ).execute()
+
 fun Request.Builder.get(url: HttpUrl, headers: Headers = Headers.headersOf(), parameters: Map<String, String> = emptyMap()) =
     this.url(url.of(parameters))
         .headers(headers)
@@ -110,6 +119,11 @@ fun Request.Builder.post(url: HttpUrl, headers: Headers, parameters: Map<String,
     this.url(url)
         .headers(headers)
         .post(FormBody.Builder().of(parameters))
+        .build()
+
+fun Request.Builder.options(url: HttpUrl) =
+    this.url(url)
+        .method("OPTIONS", null)
         .build()
 
 fun HttpUrl.of(parameters: Map<String, String>) =


### PR DESCRIPTION
Support preflight request and include allow-origin response header to relevant responses.
Resolves https://github.com/navikt/mock-oauth2-server/issues/17