### PR TITLE
Support more token signing algos

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,9 +96,7 @@ A request to `http://localhost:8080/default/.well-known/openid-configuration` wi
    ],
    "id_token_signing_alg_values_supported":[
      "ES256",
-     "ES256K",
      "ES384",
-     "ES512",
      "RS256",
      "RS384",
      "RS512",

--- a/README.md
+++ b/README.md
@@ -264,6 +264,19 @@ Example:
 }
 ```
 
+A token provider can support different `signing` algorithms. Configure your token provider and
+add this to your config with preferred `JWS algorithm`:
+
+```json
+{
+  "tokenProvider" : {
+    "keyProvider" : {
+      "algorithm" : "ES256"
+    }
+  }
+}
+```
+
 | Property | Description |
 | --- | --- |
 | `interactiveLogin` | `true` or `false`, enables login screen when redirecting to server `/authorize` endpoint |

--- a/README.md
+++ b/README.md
@@ -95,7 +95,16 @@ A request to `http://localhost:8080/default/.well-known/openid-configuration` wi
       "public"
    ],
    "id_token_signing_alg_values_supported":[
-      "RS256"
+     "ES256",
+     "ES256K",
+     "ES384",
+     "ES512",
+     "RS256",
+     "RS384",
+     "RS512",
+     "PS256",
+     "PS384",
+     "PS512"
    ]
 }
 ```

--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -78,16 +78,16 @@ inline fun <reified T : AuthorizationGrant> TokenRequest.grant(type: Class<T>): 
 
 fun TokenRequest.clientIdAsString(): String =
     this.clientAuthentication?.clientID?.value ?: this.clientID?.value
-    ?: throw OAuth2Exception(OAuth2Error.INVALID_CLIENT, "client_id cannot be null")
+        ?: throw OAuth2Exception(OAuth2Error.INVALID_CLIENT, "client_id cannot be null")
 
 fun SignedJWT.expiresIn(): Int =
     Duration.between(Instant.now(), this.jwtClaimsSet.expirationTime.toInstant()).seconds.toInt()
 
-fun SignedJWT.verifySignatureAndIssuer(issuer: Issuer, jwkSet: JWKSet): JWTClaimsSet {
+fun SignedJWT.verifySignatureAndIssuer(issuer: Issuer, jwkSet: JWKSet, jwsAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256): JWTClaimsSet {
     val jwtProcessor: ConfigurableJWTProcessor<SecurityContext?> = DefaultJWTProcessor()
     jwtProcessor.jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(JOSEObjectType("JWT"))
     val keySelector: JWSKeySelector<SecurityContext?> = JWSVerificationKeySelector(
-        JWSAlgorithm.RS256,
+        jwsAlgorithm,
         ImmutableJWKSet(jwkSet)
     )
     jwtProcessor.jwsKeySelector = keySelector
@@ -115,7 +115,6 @@ fun ClientAuthentication.requirePrivateKeyJwt(requiredAudience: String, maxLifet
                 else -> it
             }
         } ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "request must contain a valid client_assertion.")
-
 
 fun SignedJWT.with(keyId: String, type: String, algorithm: JWSAlgorithm, claimsSet: JWTClaimsSet): SignedJWT =
     SignedJWT(

--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -2,7 +2,6 @@ package no.nav.security.mock.oauth2.extensions
 
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
@@ -115,11 +114,3 @@ fun ClientAuthentication.requirePrivateKeyJwt(requiredAudience: String, maxLifet
                 else -> it
             }
         } ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "request must contain a valid client_assertion.")
-
-fun SignedJWT.with(keyId: String, type: String, algorithm: JWSAlgorithm, claimsSet: JWTClaimsSet): SignedJWT =
-    SignedJWT(
-        JWSHeader.Builder(algorithm)
-            .keyID(keyId)
-            .type(JOSEObjectType(type)).build(),
-        claimsSet
-    )

--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -2,6 +2,7 @@ package no.nav.security.mock.oauth2.extensions
 
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.source.ImmutableJWKSet
 import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
@@ -34,7 +35,6 @@ import no.nav.security.mock.oauth2.grant.TokenExchangeGrant
 import no.nav.security.mock.oauth2.invalidRequest
 import java.time.Duration
 import java.time.Instant
-import java.util.HashSet
 
 private val log = KotlinLogging.logger { }
 
@@ -78,7 +78,7 @@ inline fun <reified T : AuthorizationGrant> TokenRequest.grant(type: Class<T>): 
 
 fun TokenRequest.clientIdAsString(): String =
     this.clientAuthentication?.clientID?.value ?: this.clientID?.value
-        ?: throw OAuth2Exception(OAuth2Error.INVALID_CLIENT, "client_id cannot be null")
+    ?: throw OAuth2Exception(OAuth2Error.INVALID_CLIENT, "client_id cannot be null")
 
 fun SignedJWT.expiresIn(): Int =
     Duration.between(Instant.now(), this.jwtClaimsSet.expirationTime.toInstant()).seconds.toInt()
@@ -115,3 +115,12 @@ fun ClientAuthentication.requirePrivateKeyJwt(requiredAudience: String, maxLifet
                 else -> it
             }
         } ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "request must contain a valid client_assertion.")
+
+
+fun SignedJWT.with(keyId: String, type: String, algorithm: JWSAlgorithm, claimsSet: JWTClaimsSet): SignedJWT =
+    SignedJWT(
+        JWSHeader.Builder(algorithm)
+            .keyID(keyId)
+            .type(JOSEObjectType(type)).build(),
+        claimsSet
+    )

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -10,7 +10,6 @@ import com.nimbusds.oauth2.sdk.OAuth2Error
 import com.nimbusds.oauth2.sdk.TokenRequest
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse
-import kotlin.collections.set
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.authorizationCode
@@ -104,7 +103,6 @@ internal class AuthorizationCodeHandler(
         override fun subject(tokenRequest: TokenRequest): String = login.username
         override fun typeHeader(tokenRequest: TokenRequest): String = oAuth2TokenCallback.typeHeader(tokenRequest)
         override fun audience(tokenRequest: TokenRequest): List<String> = oAuth2TokenCallback.audience(tokenRequest)
-        override fun algorithm(): String = oAuth2TokenCallback.algorithm()
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
             oAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {
                 login.claims?.let {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -62,6 +62,7 @@ internal class AuthorizationCodeHandler(
         }
     }
 
+    // TODO add algorithm
     override fun tokenResponse(
         request: OAuth2HttpRequest,
         issuerUrl: HttpUrl,
@@ -103,6 +104,7 @@ internal class AuthorizationCodeHandler(
         override fun subject(tokenRequest: TokenRequest): String = login.username
         override fun typeHeader(tokenRequest: TokenRequest): String = oAuth2TokenCallback.typeHeader(tokenRequest)
         override fun audience(tokenRequest: TokenRequest): List<String> = oAuth2TokenCallback.audience(tokenRequest)
+        override fun algorithm(): String = oAuth2TokenCallback.algorithm()
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
             oAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {
                 login.claims?.let {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -61,7 +61,6 @@ internal class AuthorizationCodeHandler(
         }
     }
 
-    // TODO add algorithm
     override fun tokenResponse(
         request: OAuth2HttpRequest,
         issuerUrl: HttpUrl,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -5,12 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.oauth2.sdk.ErrorObject
 import com.nimbusds.oauth2.sdk.ResponseMode
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse
 import io.netty.handler.codec.http.HttpHeaderNames
 import no.nav.security.mock.oauth2.templates.TemplateMapper
+import no.nav.security.mock.oauth2.token.KeyGenerator
 import okhttp3.Headers
 
 val objectMapper: ObjectMapper = jacksonObjectMapper()
@@ -37,7 +37,7 @@ data class WellKnown(
     @JsonProperty("subject_types_supported")
     val subjectTypesSupported: List<String> = listOf("public"),
     @JsonProperty("id_token_signing_alg_values_supported")
-    val idTokenSigningAlgValuesSupported: List<String> = (JWSAlgorithm.Family.EC + JWSAlgorithm.Family.RSA).map { it.name }.toList()
+    val idTokenSigningAlgValuesSupported: List<String> = (KeyGenerator.ecAlgorithmFamily + KeyGenerator.rsaAlgorithmFamily).map { it.name }.toList()
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.oauth2.sdk.ErrorObject
 import com.nimbusds.oauth2.sdk.ResponseMode
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse
@@ -36,7 +37,7 @@ data class WellKnown(
     @JsonProperty("subject_types_supported")
     val subjectTypesSupported: List<String> = listOf("public"),
     @JsonProperty("id_token_signing_alg_values_supported")
-    val idTokenSigningAlgValuesSupported: List<String> = listOf("RS256")
+    val idTokenSigningAlgValuesSupported: List<String> = (JWSAlgorithm.Family.EC + JWSAlgorithm.Family.RSA).map { it.name }.toList()
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
@@ -56,9 +56,16 @@ data class KeyGenerator(
 
     companion object {
 
+        val rsaAlgorithmFamily = JWSAlgorithm.Family.RSA.toList()
+        val ecAlgorithmFamily = JWSAlgorithm.Family.EC.filterNot {
+            // ES256K is not a public used algorithm
+            // ES512 is counted as "legacy" and is not supported
+            it.name == "ES256K" || it.name == "ES512"
+        }
+
         private val supportedAlgorithms = listOf(
-            Algorithm(JWSAlgorithm.Family.RSA, KeyType.RSA),
-            Algorithm(JWSAlgorithm.Family.EC, KeyType.EC)
+            Algorithm(rsaAlgorithmFamily, KeyType.RSA),
+            Algorithm(ecAlgorithmFamily, KeyType.EC)
         )
 
         fun isSupported(algorithm: JWSAlgorithm) = supportedAlgorithms.flatMap { it.family }.contains(algorithm)
@@ -82,7 +89,7 @@ data class KeyGenerator(
         }
 
         data class Algorithm(
-            val family: JWSAlgorithm.Family,
+            val family: List<JWSAlgorithm>,
             val keyType: KeyType
         )
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
@@ -1,0 +1,93 @@
+package no.nav.security.mock.oauth2.token
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
+import no.nav.security.mock.oauth2.OAuth2Exception
+import java.security.KeyPairGenerator
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+import java.security.interfaces.RSAPrivateKey
+import java.security.interfaces.RSAPublicKey
+
+data class KeyGenerator(
+    var keyGenerator: KeyPairGenerator = KeyPairGenerator.getInstance(RSA_KEY_TYPE).apply {
+        this.initialize(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+    },
+    var currentAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256
+) {
+    fun generateKey(keyId: String): JWK {
+        if (keyGenerator.algorithm == RSA_KEY_TYPE) {
+            return keyGenerator.generateRSAKey(keyId)
+        }
+        return keyGenerator.generateECKey(keyId, currentAlgorithm)
+    }
+
+    private fun KeyPairGenerator.generateECKey(keyId: String, algorithm: JWSAlgorithm): JWK =
+        generateKeyPair()
+            .let {
+                ECKey.Builder(toCurve(algorithm), it.public as ECPublicKey)
+                    .privateKey(it.private as ECPrivateKey)
+                    .keyUse(KeyUse.SIGNATURE)
+                    .keyID(keyId)
+                    .build()
+            }
+
+    private fun toCurve(algorithm: JWSAlgorithm): Curve {
+        return requireNotNull(
+            Curve.forJWSAlgorithm(algorithm).single()
+        ) {
+            throw OAuth2Exception("Unsupported: $algorithm")
+        }
+    }
+
+    private fun KeyPairGenerator.generateRSAKey(keyId: String): JWK =
+        generateKeyPair()
+            .let {
+                RSAKey.Builder(it.public as RSAPublicKey)
+                    .privateKey(it.private as RSAPrivateKey)
+                    .keyUse(KeyUse.SIGNATURE)
+                    .keyID(keyId)
+                    .build()
+            }
+
+    companion object {
+
+        const val RSA_KEY_TYPE = "RSA"
+        const val EC_KEY_TYPE = "EC"
+
+        private val supportedAlgorithms =
+            mapOf(
+                JWSAlgorithm.RS256 to Requirement(RSA_KEY_TYPE, RSAKeyGenerator.MIN_KEY_SIZE_BITS),
+                JWSAlgorithm.RS512 to Requirement(RSA_KEY_TYPE, 512),
+                JWSAlgorithm.ES256 to Requirement(EC_KEY_TYPE, 256)
+            )
+
+        fun generate(algorithm: String): KeyGenerator {
+            val parsedAlgo = JWSAlgorithm.parse(algorithm)
+
+            val algo = requireNotNull(supportedAlgorithms[parsedAlgo]?.type) {
+                throw OAuth2Exception("Unsupported: $algorithm")
+            }
+
+            val key = requireNotNull(supportedAlgorithms[parsedAlgo]?.keySize) {
+                throw OAuth2Exception("Unsupported: $algorithm")
+            }
+
+            return KeyGenerator(
+                KeyPairGenerator.getInstance(algo).apply {
+                    this.initialize(key)
+                }, parsedAlgo
+            )
+        }
+
+        data class Requirement(
+            val type: String,
+            val keySize: Int,
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
@@ -4,6 +4,7 @@ import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import com.nimbusds.jose.jwk.gen.RSAKeyGenerator
@@ -15,16 +16,14 @@ import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
 
 data class KeyGenerator(
-    var keyGenerator: KeyPairGenerator = KeyPairGenerator.getInstance(RSA_KEY_TYPE).apply {
-        this.initialize(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
-    },
-    var currentAlgorithm: JWSAlgorithm = JWSAlgorithm.RS256
+    val algorithm: JWSAlgorithm = JWSAlgorithm.RS256,
+    var keyGenerator: KeyPairGenerator = generate(algorithm.name)
 ) {
     fun generateKey(keyId: String): JWK {
-        if (keyGenerator.algorithm == RSA_KEY_TYPE) {
-            return keyGenerator.generateRSAKey(keyId)
+        if (keyGenerator.algorithm != KeyType.RSA.value) {
+            return keyGenerator.generateECKey(keyId, algorithm)
         }
-        return keyGenerator.generateECKey(keyId, currentAlgorithm)
+        return keyGenerator.generateRSAKey(keyId)
     }
 
     private fun KeyPairGenerator.generateECKey(keyId: String, algorithm: JWSAlgorithm): JWK =
@@ -57,37 +56,34 @@ data class KeyGenerator(
 
     companion object {
 
-        const val RSA_KEY_TYPE = "RSA"
-        const val EC_KEY_TYPE = "EC"
+        private val supportedAlgorithms = listOf(
+            Algorithm(JWSAlgorithm.Family.RSA, KeyType.RSA),
+            Algorithm(JWSAlgorithm.Family.EC, KeyType.EC)
+        )
 
-        private val supportedAlgorithms =
-            mapOf(
-                JWSAlgorithm.RS256 to Requirement(RSA_KEY_TYPE, RSAKeyGenerator.MIN_KEY_SIZE_BITS),
-                JWSAlgorithm.RS512 to Requirement(RSA_KEY_TYPE, 512),
-                JWSAlgorithm.ES256 to Requirement(EC_KEY_TYPE, 256)
-            )
+        fun isSupported(algorithm: JWSAlgorithm) = supportedAlgorithms.flatMap { it.family }.contains(algorithm)
 
-        fun generate(algorithm: String): KeyGenerator {
+        fun generate(algorithm: String): KeyPairGenerator {
             val parsedAlgo = JWSAlgorithm.parse(algorithm)
-
-            val algo = requireNotNull(supportedAlgorithms[parsedAlgo]?.type) {
-                throw OAuth2Exception("Unsupported: $algorithm")
-            }
-
-            val key = requireNotNull(supportedAlgorithms[parsedAlgo]?.keySize) {
-                throw OAuth2Exception("Unsupported: $algorithm")
-            }
-
-            return KeyGenerator(
-                KeyPairGenerator.getInstance(algo).apply {
-                    this.initialize(key)
-                }, parsedAlgo
-            )
+            return supportedAlgorithms.mapNotNull {
+                if (it.family.contains(parsedAlgo)) {
+                    KeyGenerator(
+                        parsedAlgo,
+                        KeyPairGenerator.getInstance(it.keyType.value).apply {
+                            if (it.keyType.value != KeyType.RSA.value) {
+                                this.initialize(parsedAlgo.name.subSequence(2, 5).toString().toInt())
+                            } else {
+                                this.initialize(RSAKeyGenerator.MIN_KEY_SIZE_BITS)
+                            }
+                        }
+                    ).keyGenerator
+                } else null
+            }.singleOrNull() ?: throw OAuth2Exception("Unsupported algorithm: $algorithm")
         }
 
-        data class Requirement(
-            val type: String,
-            val keySize: Int,
+        data class Algorithm(
+            val family: JWSAlgorithm.Family,
+            val keyType: KeyType
         )
     }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -42,7 +42,7 @@ open class KeyProvider @JvmOverloads constructor(
 
     fun algorithm(): JWSAlgorithm = JWSAlgorithm.parse(algorithm)
 
-    fun keyType()  = generator.keyGenerator.algorithm
+    fun keyType(): String = generator.keyGenerator.algorithm
 
     fun generate(algorithm: String) {
         generator = KeyGenerator(JWSAlgorithm.parse(algorithm))

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -1,34 +1,79 @@
 package no.nav.security.mock.oauth2.token
 
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
+import no.nav.security.mock.oauth2.OAuth2Exception
 import java.security.KeyPairGenerator
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingDeque
 
+const val RSA_KEY_TYPE = "RSA"
+const val EC_KEY_TYPE = "EC"
+const val RSA_KEY_SIZE_256 = 2048
+
 open class KeyProvider @JvmOverloads constructor(
-    private val initialKeys: List<RSAKey> = keysFromFile(INITIAL_KEYS_FILE)
+    private val initialKeys: List<JWK> = keysFromFile(INITIAL_KEYS_FILE),
+    private val keyTypeAndKeySize: Pair<String, Int> = RSA_KEY_TYPE to RSA_KEY_SIZE_256
 ) {
-    private val signingKeys: ConcurrentHashMap<String, RSAKey> = ConcurrentHashMap()
+    private val signingKeys: ConcurrentHashMap<String, JWK> = ConcurrentHashMap()
 
-    private val generator = KeyPairGenerator.getInstance("RSA").apply { this.initialize(2048) }
+    private val generator = KeyPairGenerator.getInstance(keyTypeAndKeySize.first).apply { this.initialize(keyTypeAndKeySize.second) }
 
-    private val keyDeque = LinkedBlockingDeque<RSAKey>().apply {
+    private val keyDeque = LinkedBlockingDeque<JWK>().apply {
         initialKeys.forEach {
             put(it)
         }
     }
 
-    fun signingKey(keyId: String): RSAKey = signingKeys.computeIfAbsent(keyId) { keyFromDequeOrNew(keyId) }
+    fun signingKey(keyId: String): JWK = signingKeys.computeIfAbsent(keyId) { keyFromDequeOrNew(keyId) }
 
-    private fun keyFromDequeOrNew(keyId: String): RSAKey = keyDeque.poll()?.let {
-        RSAKey.Builder(it).keyID(keyId).build()
-    } ?: generator.generateRSAKey(keyId)
+    private fun keyFromDequeOrNew(keyId: String): JWK = keyDeque.poll()?.let { polledJwk ->
+        when (polledJwk.keyType.value) {
+            RSA_KEY_TYPE -> {
+                RSAKey.Builder(polledJwk.toRSAKey()).keyID(keyId).build()
+            }
+            EC_KEY_TYPE -> {
+                ECKey.Builder(polledJwk.toECKey()).keyID(keyId).build()
+            }
+            else -> {
+                throw OAuth2Exception("Unsupported key type (kty): ${polledJwk.keyType.value}")
+            }
+        }
+    } ?: generator.generateKey(keyId, keyTypeAndKeySize.first)
 
-    private fun KeyPairGenerator.generateRSAKey(keyId: String): RSAKey =
+
+    private fun KeyPairGenerator.generateKey(keyId: String, keyType: String): JWK =
+        when (keyType) {
+            RSA_KEY_TYPE -> {
+                this.generateRSAKey(keyId)
+            }
+            EC_KEY_TYPE -> {
+                this.generateECKey(keyId)
+            }
+            else -> {
+                throw OAuth2Exception("Unsupported key type (kty): $keyType")
+            }
+        }
+
+    private fun KeyPairGenerator.generateECKey(keyId: String): JWK =
+        generateKeyPair()
+            .let {
+                ECKey.Builder(Curve.P_256, it.public as ECPublicKey)
+                    .privateKey(it.private as ECPrivateKey)
+                    .keyUse(KeyUse.SIGNATURE)
+                    .keyID(keyId)
+                    .build()
+            }
+
+    private fun KeyPairGenerator.generateRSAKey(keyId: String): JWK =
         generateKeyPair()
             .let {
                 RSAKey.Builder(it.public as RSAPublicKey)
@@ -41,10 +86,10 @@ open class KeyProvider @JvmOverloads constructor(
     companion object {
         const val INITIAL_KEYS_FILE = "/mock-oauth2-server-keys.json"
 
-        fun keysFromFile(filename: String): List<RSAKey> {
+        fun keysFromFile(filename: String): List<JWK> {
             val keysFromFile = KeyProvider::class.java.getResource(filename)
             if (keysFromFile != null) {
-                return JWKSet.parse(keysFromFile.readText()).keys.map { it as RSAKey }
+                return JWKSet.parse(keysFromFile.readText()).keys.map { it as JWK }
             }
             return emptyList()
         }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -1,36 +1,30 @@
 package no.nav.security.mock.oauth2.token
 
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
-import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
 import no.nav.security.mock.oauth2.OAuth2Exception
-import java.security.KeyPairGenerator
-import java.security.interfaces.ECPrivateKey
-import java.security.interfaces.ECPublicKey
-import java.security.interfaces.RSAPrivateKey
-import java.security.interfaces.RSAPublicKey
+import no.nav.security.mock.oauth2.token.KeyGenerator.Companion.EC_KEY_TYPE
+import no.nav.security.mock.oauth2.token.KeyGenerator.Companion.RSA_KEY_TYPE
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingDeque
 
-const val RSA_KEY_TYPE = "RSA"
-const val EC_KEY_TYPE = "EC"
-const val RSA_KEY_SIZE_256 = 2048
-
 open class KeyProvider @JvmOverloads constructor(
     private val initialKeys: List<JWK> = keysFromFile(INITIAL_KEYS_FILE),
-    private val keyTypeAndKeySize: Pair<String, Int> = RSA_KEY_TYPE to RSA_KEY_SIZE_256
 ) {
     private val signingKeys: ConcurrentHashMap<String, JWK> = ConcurrentHashMap()
 
-    private val generator = KeyPairGenerator.getInstance(keyTypeAndKeySize.first).apply { this.initialize(keyTypeAndKeySize.second) }
+    private var generator: KeyGenerator = KeyGenerator()
 
     private val keyDeque = LinkedBlockingDeque<JWK>().apply {
         initialKeys.forEach {
             put(it)
         }
+    }
+
+    fun regenerate(algorithm: String) {
+        generator = KeyGenerator.generate(algorithm)
     }
 
     fun signingKey(keyId: String): JWK = signingKeys.computeIfAbsent(keyId) { keyFromDequeOrNew(keyId) }
@@ -44,44 +38,10 @@ open class KeyProvider @JvmOverloads constructor(
                 ECKey.Builder(polledJwk.toECKey()).keyID(keyId).build()
             }
             else -> {
-                throw OAuth2Exception("Unsupported key type (kty): ${polledJwk.keyType.value}")
+                throw OAuth2Exception("Unsupported key type: ${polledJwk.keyType.value}")
             }
         }
-    } ?: generator.generateKey(keyId, keyTypeAndKeySize.first)
-
-
-    private fun KeyPairGenerator.generateKey(keyId: String, keyType: String): JWK =
-        when (keyType) {
-            RSA_KEY_TYPE -> {
-                this.generateRSAKey(keyId)
-            }
-            EC_KEY_TYPE -> {
-                this.generateECKey(keyId)
-            }
-            else -> {
-                throw OAuth2Exception("Unsupported key type (kty): $keyType")
-            }
-        }
-
-    private fun KeyPairGenerator.generateECKey(keyId: String): JWK =
-        generateKeyPair()
-            .let {
-                ECKey.Builder(Curve.P_256, it.public as ECPublicKey)
-                    .privateKey(it.private as ECPrivateKey)
-                    .keyUse(KeyUse.SIGNATURE)
-                    .keyID(keyId)
-                    .build()
-            }
-
-    private fun KeyPairGenerator.generateRSAKey(keyId: String): JWK =
-        generateKeyPair()
-            .let {
-                RSAKey.Builder(it.public as RSAPublicKey)
-                    .privateKey(it.private as RSAPrivateKey)
-                    .keyUse(KeyUse.SIGNATURE)
-                    .keyID(keyId)
-                    .build()
-            }
+    } ?: generator.generateKey(keyId)
 
     companion object {
         const val INITIAL_KEYS_FILE = "/mock-oauth2-server-keys.json"

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -1,21 +1,22 @@
 package no.nav.security.mock.oauth2.token
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.RSAKey
 import no.nav.security.mock.oauth2.OAuth2Exception
-import no.nav.security.mock.oauth2.token.KeyGenerator.Companion.EC_KEY_TYPE
-import no.nav.security.mock.oauth2.token.KeyGenerator.Companion.RSA_KEY_TYPE
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingDeque
 
 open class KeyProvider @JvmOverloads constructor(
     private val initialKeys: List<JWK> = keysFromFile(INITIAL_KEYS_FILE),
+    private val algorithm: String = JWSAlgorithm.RS256.name
 ) {
     private val signingKeys: ConcurrentHashMap<String, JWK> = ConcurrentHashMap()
 
-    private var generator: KeyGenerator = KeyGenerator()
+    private var generator: KeyGenerator = KeyGenerator(JWSAlgorithm.parse(algorithm))
 
     private val keyDeque = LinkedBlockingDeque<JWK>().apply {
         initialKeys.forEach {
@@ -23,18 +24,14 @@ open class KeyProvider @JvmOverloads constructor(
         }
     }
 
-    fun regenerate(algorithm: String) {
-        generator = KeyGenerator.generate(algorithm)
-    }
-
     fun signingKey(keyId: String): JWK = signingKeys.computeIfAbsent(keyId) { keyFromDequeOrNew(keyId) }
 
     private fun keyFromDequeOrNew(keyId: String): JWK = keyDeque.poll()?.let { polledJwk ->
         when (polledJwk.keyType.value) {
-            RSA_KEY_TYPE -> {
+            KeyType.RSA.value -> {
                 RSAKey.Builder(polledJwk.toRSAKey()).keyID(keyId).build()
             }
-            EC_KEY_TYPE -> {
+            KeyType.EC.value -> {
                 ECKey.Builder(polledJwk.toECKey()).keyID(keyId).build()
             }
             else -> {
@@ -42,6 +39,14 @@ open class KeyProvider @JvmOverloads constructor(
             }
         }
     } ?: generator.generateKey(keyId)
+
+    fun algorithm(): JWSAlgorithm = JWSAlgorithm.parse(algorithm)
+
+    fun keyType()  = generator.keyGenerator.algorithm
+
+    fun generate(algorithm: String) {
+        generator = KeyGenerator(JWSAlgorithm.parse(algorithm))
+    }
 
     companion object {
         const val INITIAL_KEYS_FILE = "/mock-oauth2-server-keys.json"

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -18,7 +18,7 @@ interface OAuth2TokenCallback {
     fun audience(tokenRequest: TokenRequest): List<String>
     fun addClaims(tokenRequest: TokenRequest): Map<String, Any>
     fun tokenExpiry(): Long
-    fun algorithm(): String
+    // fun algorithm(): String
 }
 
 // TODO: for JwtBearerGrant and TokenExchange should be able to ovverride sub, make sub nullable and return some default
@@ -30,7 +30,6 @@ open class DefaultOAuth2TokenCallback @JvmOverloads constructor(
     private val audience: List<String>? = null,
     private val claims: Map<String, Any> = emptyMap(),
     private val expiry: Long = 3600,
-    private val algorithm: String = JWSAlgorithm.RS256.name
 ) : OAuth2TokenCallback {
 
     override fun issuerId(): String = issuerId
@@ -67,8 +66,6 @@ open class DefaultOAuth2TokenCallback @JvmOverloads constructor(
         }
 
     override fun tokenExpiry(): Long = expiry
-
-    override fun algorithm(): String = algorithm
 }
 
 data class RequestMappingTokenCallback(
@@ -92,8 +89,6 @@ data class RequestMappingTokenCallback(
         requestMappings.getClaims(tokenRequest)
 
     override fun tokenExpiry(): Long = tokenExpiry
-
-    override fun algorithm(): String = algorithm
 
     private fun Set<RequestMapping>.getClaims(tokenRequest: TokenRequest) =
         firstOrNull { it.isMatch(tokenRequest) }?.claims ?: emptyMap()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -1,7 +1,6 @@
 package no.nav.security.mock.oauth2.token
 
 import com.nimbusds.jose.JOSEObjectType
-import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.TokenRequest
 import no.nav.security.mock.oauth2.extensions.clientIdAsString
@@ -18,7 +17,6 @@ interface OAuth2TokenCallback {
     fun audience(tokenRequest: TokenRequest): List<String>
     fun addClaims(tokenRequest: TokenRequest): Map<String, Any>
     fun tokenExpiry(): Long
-    // fun algorithm(): String
 }
 
 // TODO: for JwtBearerGrant and TokenExchange should be able to ovverride sub, make sub nullable and return some default
@@ -72,7 +70,6 @@ data class RequestMappingTokenCallback(
     val issuerId: String,
     val requestMappings: Set<RequestMapping>,
     val tokenExpiry: Long = Duration.ofHours(1).toSeconds(),
-    val algorithm: String = JWSAlgorithm.RS256.name
 ) : OAuth2TokenCallback {
     override fun issuerId(): String = issuerId
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -5,7 +5,6 @@ import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
 import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.RSASSASigner
-import com.nimbusds.jose.jwk.Curve
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT

--- a/src/main/resources/mock-oauth2-server-keys-ec.json
+++ b/src/main/resources/mock-oauth2-server-keys-ec.json
@@ -1,0 +1,22 @@
+{
+  "keys": [
+    {
+      "kty": "EC",
+      "d": "o9INzHyU_I97djF36YQRpHCJxFTgDTbS1OtwUnHc34U",
+      "use": "sig",
+      "crv": "P-256",
+      "kid": "issuer0",
+      "x": "umybCYzE-VX_UAIJaX3wc-GTOgB7WDp7A3JJAKW_hqU",
+      "y": "m_sCzuMjiBSQ7At9yNktMQvE1cCKq68jO7wnRczwKw8"
+    },
+    {
+      "kty": "EC",
+      "d": "yK-ntUEZxKEH_QQZZVtmjpCQPfhyKmaqbCD9-3apDbk",
+      "use": "sig",
+      "crv": "P-256",
+      "kid": "issuer1",
+      "x": "YLAxep2KtJzgr6JZmlVgwmhoH08QKwG_ojgymdtcOkM",
+      "y": "jpDJ7qE5g0iIBEBIrilQrOniOgbaKw0UjMky99j18G4"
+    }
+  ]
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
@@ -1,12 +1,14 @@
 package no.nav.security.mock.oauth2
 
 import com.fasterxml.jackson.databind.JsonMappingException
+import com.nimbusds.jose.jwk.KeyType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.Matcher
 import io.kotest.matchers.MatcherResult
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.types.beInstanceOf
 import no.nav.security.mock.oauth2.FullConfig.configJson
 import no.nav.security.mock.oauth2.HttpServerConfig.mockWebServerWithGeneratedKeystore
@@ -16,6 +18,9 @@ import no.nav.security.mock.oauth2.HttpServerConfig.nettyWithProvidedKeystore
 import no.nav.security.mock.oauth2.HttpServerConfig.withMockWebServerWrapper
 import no.nav.security.mock.oauth2.HttpServerConfig.withNettyHttpServer
 import no.nav.security.mock.oauth2.HttpServerConfig.withUnknownHttpServer
+import no.nav.security.mock.oauth2.SigningKey.signingJsonGenerated
+import no.nav.security.mock.oauth2.SigningKey.signingJsonSpecified
+import no.nav.security.mock.oauth2.SigningKey.signingJsonUnsupported
 import no.nav.security.mock.oauth2.http.MockWebServerWrapper
 import no.nav.security.mock.oauth2.http.NettyWrapper
 import org.intellij.lang.annotations.Language
@@ -48,6 +53,26 @@ internal class OAuth2ConfigTest {
         config.tokenCallbacks.map {
             it.issuerId()
         }.toList() shouldContainAll listOf("issuer1", "issuer2")
+    }
+
+    @Test
+    fun `create tokenProvider with generated signing algorithm EC`() {
+        val config = OAuth2Config.fromJson(signingJsonGenerated)
+        config.tokenProvider.publicJwkSet().keys[0].keyType.value shouldBe KeyType.EC.value
+    }
+
+    @Test
+    fun `create tokenProvider with specified signing algorithm EC`() {
+        val config = OAuth2Config.fromJson(signingJsonSpecified)
+        config.tokenProvider.publicJwkSet().keys[0].keyType.value shouldBe KeyType.EC.value
+        config.tokenProvider.publicJwkSet("issuer0").keys[0].keyID shouldBe "issuer0"
+    }
+
+    @Test
+    fun `create config from json with an unsupported algorithm should throw Oauth2Exception`() {
+        shouldThrow<JsonMappingException> {
+            OAuth2Config.fromJson(signingJsonUnsupported)
+        }.message shouldContain "Unsupported algorithm: EdDSA"
     }
 
     @Test
@@ -142,6 +167,42 @@ object FullConfig {
         }
       ]
     }
+    """.trimIndent()
+}
+
+object SigningKey {
+    @Language("json")
+    val signingJsonGenerated = """
+        {
+        "tokenProvider" : {
+            "keyProvider" : {
+               "algorithm" : "ES256"
+            }
+          }
+        }
+    """.trimIndent()
+
+    @Language("json")
+    val signingJsonSpecified = """
+        {
+        "tokenProvider" : {
+            "keyProvider" : {
+               "initialKeys" : "{\"kty\": \"EC\",\"d\": \"o9INzHyU_I97djF36YQRpHCJxFTgDTbS1OtwUnHc34U\",\"use\":\"sig\",\"crv\": \"P-256\",\"kid\": \"issuer0\",\"x\": \"umybCYzE-VX_UAIJaX3wc-GTOgB7WDp7A3JJAKW_hqU\",\"y\": \"m_sCzuMjiBSQ7At9yNktMQvE1cCKq68jO7wnRczwKw8\"}",
+               "algorithm" : "ES256"
+            }
+          }
+        }
+    """.trimIndent()
+
+    @Language("json")
+    val signingJsonUnsupported = """
+        {
+        "tokenProvider" : {
+            "keyProvider" : {
+               "algorithm" : "EdDSA"
+            }
+          }
+        }
     """.trimIndent()
 }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/login/LoginRequestHandlerTest.kt
@@ -17,7 +17,7 @@ internal class LoginRequestHandlerTest {
     private val handler = LoginRequestHandler(templateMapper, OAuth2Config())
 
     @Test
-    fun `loginSubmit should return login with username and claims from form params`(){
+    fun `loginSubmit should return login with username and claims from form params`() {
         handler.loginSubmit(request("username=foo&claims=someJsonString")).asClue {
             it shouldBe Login("foo", claims = "someJsonString")
         }
@@ -39,5 +39,4 @@ internal class LoginRequestHandlerTest {
             method = "POST",
             body = body
         )
-
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyGeneratorTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyGeneratorTest.kt
@@ -1,0 +1,90 @@
+package no.nav.security.mock.oauth2.token
+
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.crypto.RSASSASigner
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.KeyType
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.id.Issuer
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.matchers.shouldBe
+import no.nav.security.mock.oauth2.extensions.verifySignatureAndIssuer
+import no.nav.security.mock.oauth2.token.KeyGenerator.Companion.ecAlgorithmFamily
+import no.nav.security.mock.oauth2.token.KeyGenerator.Companion.rsaAlgorithmFamily
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Date
+
+class KeyGeneratorTest {
+
+    @Test
+    fun `verify RSA signing keys with the right algorithm is created`() {
+        rsaAlgorithmFamily.forEachIndexed { index, jwsAlgorithm ->
+
+            val generator = KeyGenerator(algorithm = jwsAlgorithm)
+            generator.algorithm.toString() shouldBe jwsAlgorithm.name
+
+            val keyId = "test$index"
+            val keys = generator.generateKey(keyId)
+
+            keys.keyID shouldBe keyId
+            keys.keyType.toString() shouldBe KeyType.RSA.value
+            keys.keyUse.toString() shouldBe "sig"
+
+            val issuer = Issuer("issuer$index")
+            val jwt = jwtWith(issuer.value, keyId, JOSEObjectType.JWT.type, jwsAlgorithm)
+            val jwkSet = JWKSet.parse("""{"keys": [$keys]}""".trimIndent())
+
+            shouldNotThrow<Exception> {
+                jwt.apply {
+                    sign(RSASSASigner(keys.toRSAKey().toRSAPrivateKey()))
+                }
+                jwt.verifySignatureAndIssuer(issuer, jwkSet, jwsAlgorithm)
+            }
+        }
+    }
+
+    @Test
+    fun `verify EC signing keys with the right algorithm is created`() {
+        ecAlgorithmFamily.forEachIndexed { index, jwsAlgorithm ->
+
+            val generator = KeyGenerator(algorithm = jwsAlgorithm)
+            generator.algorithm.toString() shouldBe jwsAlgorithm.name
+
+            val keyId = "test$index"
+            val keys = generator.generateKey(keyId)
+
+            keys.keyID shouldBe keyId
+            keys.keyType.toString() shouldBe KeyType.EC.value
+            keys.keyUse.toString() shouldBe "sig"
+
+            val issuer = Issuer("issuer$index")
+            val jwt = jwtWith(issuer.value, keyId, JOSEObjectType.JWT.type, jwsAlgorithm)
+            val jwkSet = JWKSet.parse("""{"keys": [$keys]}""".trimIndent())
+
+            shouldNotThrow<Exception> {
+                jwt.apply {
+                    sign(ECDSASigner(keys.toECKey().toECPrivateKey()))
+                }
+                jwt.verifySignatureAndIssuer(issuer, jwkSet, jwsAlgorithm)
+            }
+        }
+    }
+
+    private fun jwtWith(issuer: String, keyId: String, type: String, algorithm: JWSAlgorithm): SignedJWT =
+        SignedJWT(
+            JWSHeader.Builder(algorithm)
+                .keyID(keyId)
+                .type(JOSEObjectType(type)).build(),
+            JWTClaimsSet.Builder()
+                .issuer(issuer)
+                .subject("test")
+                .issueTime(Date.from(Instant.now()))
+                .expirationTime(Date.from(Instant.now().plusSeconds(20)))
+                .build()
+        )
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyProviderTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyProviderTest.kt
@@ -41,7 +41,8 @@ internal class KeyProviderTest {
 
     @Test
     fun `signingKey should return a EC key from initial keys file until deque is empty`() {
-        val provider = KeyProvider(KeyProvider.keysFromFile("/mock-oauth2-server-keys-ec.json"), EC_KEY_TYPE to 256)
+        val provider = KeyProvider(KeyProvider.keysFromFile("/mock-oauth2-server-keys-ec.json"))
+        provider.regenerate("ES256")
         val initialPublicKeys = initialEcPublicKeys()
 
         for (i in initialPublicKeys.indices) {
@@ -58,7 +59,7 @@ internal class KeyProviderTest {
     }
 
     @Test
-    fun `signingKey should return a key from provided constructor arg until deque is empty`() {
+    fun `signingKey should return a RSA key from provided constructor arg until deque is empty`() {
         val initialKeys = generateKeys(2)
         val provider = KeyProvider(initialKeys)
         val initialPublicKeys = initialKeys.map { it.toRSAPublicKey() }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProviderRSATest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProviderRSATest.kt
@@ -1,0 +1,104 @@
+package no.nav.security.mock.oauth2.token
+
+import com.nimbusds.jose.jwk.KeyType
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.proc.BadJOSEException
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.GrantType
+import com.nimbusds.oauth2.sdk.id.Issuer
+import io.kotest.assertions.asClue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.security.mock.oauth2.extensions.verifySignatureAndIssuer
+import no.nav.security.mock.oauth2.testutils.nimbusTokenRequest
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+internal class OAuth2TokenProviderRSATest {
+    private val tokenProvider = OAuth2TokenProvider()
+
+    @Test
+    fun `public jwks returns public part of JWKs`() {
+        val jwkSet = tokenProvider.publicJwkSet()
+        jwkSet.keys.any { it.isPrivate } shouldNotBe true
+    }
+
+    @Test
+    fun `all keys in public jwks should contain kty, use and kid`() {
+        val jwkSet = tokenProvider.publicJwkSet()
+        jwkSet.keys.forEach {
+            it.keyID shouldNotBe null
+            it.keyType shouldBe KeyType.RSA
+            it.keyUse shouldBe KeyUse.SIGNATURE
+        }
+    }
+
+    @Test
+    fun `claims from tokencallback should be added to token in tokenExchange`() {
+        val initialToken = tokenProvider.jwt(
+            mapOf(
+                "iss" to "http://initialissuer",
+                "sub" to "initialsubject",
+                "aud" to "initialaudience",
+                "initialclaim" to "initialclaim"
+            )
+        )
+
+        tokenProvider.exchangeAccessToken(
+            tokenRequest = nimbusTokenRequest(
+                "myclient",
+                "grant_type" to GrantType.JWT_BEARER.value,
+                "scope" to "scope1",
+                "assertion" to initialToken.serialize()
+            ),
+            issuerUrl = "http://default_if_not_overridden".toHttpUrl(),
+            claimsSet = initialToken.jwtClaimsSet,
+            oAuth2TokenCallback = DefaultOAuth2TokenCallback(
+                claims = mapOf(
+                    "extraclaim" to "extra",
+                    "iss" to "http://overrideissuer"
+                )
+            )
+        ).jwtClaimsSet.asClue {
+            it.issuer shouldBe "http://overrideissuer"
+            it.subject shouldBe "initialsubject"
+            it.audience shouldBe listOf("scope1")
+            it.claims["initialclaim"] shouldBe "initialclaim"
+            it.claims["extraclaim"] shouldBe "extra"
+        }
+    }
+
+    @Test
+    fun `publicJwks should return different signing key for each issuerId`() {
+        val keys1 = tokenProvider.publicJwkSet("issuer1").toJSONObject()
+        keys1 shouldBe tokenProvider.publicJwkSet("issuer1").toJSONObject()
+        val keys2 = tokenProvider.publicJwkSet("issuer2").toJSONObject()
+        keys2 shouldNotBe keys1
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["issuer1", "issuer2"])
+    fun `ensure idToken is signed with same key as returned from public jwks`(issuerId: String) {
+
+        val issuer = Issuer("http://localhost/$issuerId")
+        idToken(issuer.toString()).verifySignatureAndIssuer(issuer, tokenProvider.publicJwkSet(issuerId))
+
+        shouldThrow<BadJOSEException> {
+            idToken(issuer.toString()).verifySignatureAndIssuer(issuer, tokenProvider.publicJwkSet("shouldfail"))
+        }
+    }
+
+    private fun idToken(issuerUrl: String): SignedJWT =
+        tokenProvider.idToken(
+            tokenRequest = nimbusTokenRequest(
+                "client1",
+                "grant_type" to "authorization_code",
+                "code" to "123"
+            ),
+            issuerUrl = issuerUrl.toHttpUrl(),
+            oAuth2TokenCallback = DefaultOAuth2TokenCallback()
+        )
+}


### PR DESCRIPTION
Ive been taken some choices that may not be in the scope of this issue. 
But its up for discussion.
Ive added support for algos supported by nimbus:   

EC:
    "ES256", 
    "ES384"
    
RSA: 
    "RS256",
     "RS384",
     "RS512",
     "PS256",
     "PS384",
     "PS512"  

Not supported by nibmbus (smoked out with some testing)  "ES256K",   "ES512"