### PR TITLE
Feature implicit grant

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -26,12 +26,15 @@ import com.nimbusds.oauth2.sdk.http.HTTPRequest
 import com.nimbusds.oauth2.sdk.id.Issuer
 import com.nimbusds.oauth2.sdk.pkce.CodeChallenge
 import com.nimbusds.oauth2.sdk.pkce.CodeVerifier
+import com.nimbusds.oauth2.sdk.token.AccessToken
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import com.nimbusds.openid.connect.sdk.OIDCScopeValue
 import com.nimbusds.openid.connect.sdk.Prompt
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.grant.TokenExchangeGrant
+import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
 import no.nav.security.mock.oauth2.invalidRequest
 import java.time.Duration
 import java.time.Instant
@@ -116,3 +119,6 @@ fun ClientAuthentication.requirePrivateKeyJwt(requiredAudience: String, maxLifet
                 else -> it
             }
         } ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "request must contain a valid client_assertion.")
+
+fun OAuth2TokenResponse.toAccessToken(): AccessToken =
+    BearerAccessToken.parse("${this.tokenType} ${this.accessToken}")

--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -16,6 +16,7 @@ import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import com.nimbusds.oauth2.sdk.AuthorizationCode
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant
 import com.nimbusds.oauth2.sdk.AuthorizationGrant
+import com.nimbusds.oauth2.sdk.AuthorizationRequest
 import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.OAuth2Error
 import com.nimbusds.oauth2.sdk.TokenRequest
@@ -38,7 +39,7 @@ import java.util.HashSet
 
 private val log = KotlinLogging.logger { }
 
-fun AuthenticationRequest.isPrompt(): Boolean =
+fun AuthorizationRequest.isPrompt(): Boolean =
     this.prompt?.any {
         it == Prompt.Type.LOGIN || it == Prompt.Type.CONSENT || it == Prompt.Type.SELECT_ACCOUNT
     } ?: false

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ConfigurableAuthorizationResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ConfigurableAuthorizationResponse.kt
@@ -1,0 +1,34 @@
+package no.nav.security.mock.oauth2.grant
+
+import com.nimbusds.oauth2.sdk.AuthorizationRequest
+import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse
+import com.nimbusds.oauth2.sdk.token.AccessToken
+
+class ConfigurableAuthorizationResponse(
+    private val authorizationRequest: AuthorizationRequest,
+    accessToken: AccessToken,
+    private val expiresIn: Int,
+) : AuthorizationSuccessResponse(
+    authorizationRequest.redirectionURI,
+    null,
+    accessToken,
+    authorizationRequest.state,
+    authorizationRequest.impliedResponseMode()
+) {
+    override fun toParameters(): MutableMap<String, MutableList<String>> {
+        return mutableMapOf<String, MutableList<String>>()
+            .with("access_token", accessToken.value)
+            .with("state", authorizationRequest.state.value)
+            .with("token_type", accessToken.type.value)
+            .with("expires_in", expiresIn.toString()).also { fragments ->
+                authorizationRequest.scope?.let {
+                    fragments["scope"] = mutableListOf(it.toString())
+                }
+            }
+    }
+
+    private fun MutableMap<String, MutableList<String>>.with(key: String, value: String): MutableMap<String, MutableList<String>> {
+        this[key] = mutableListOf(value)
+        return this
+    }
+}

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ConfigurableAuthorizationResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ConfigurableAuthorizationResponse.kt
@@ -20,9 +20,9 @@ class ConfigurableAuthorizationResponse(
             .with("access_token", accessToken.value)
             .with("state", authorizationRequest.state.value)
             .with("token_type", accessToken.type.value)
-            .with("expires_in", expiresIn.toString()).also { fragments ->
+            .with("expires_in", expiresIn.toString()).also { params ->
                 authorizationRequest.scope?.let {
-                    fragments["scope"] = mutableListOf(it.toString())
+                    params.with("scope", it.toString())
                 }
             }
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrant.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrant.kt
@@ -1,0 +1,24 @@
+package no.nav.security.mock.oauth2.grant
+
+import com.nimbusds.oauth2.sdk.AuthorizationGrant
+import com.nimbusds.oauth2.sdk.AuthorizationRequest
+import com.nimbusds.oauth2.sdk.GrantType
+import com.nimbusds.oauth2.sdk.TokenRequest
+import okhttp3.HttpUrl
+
+internal class ImplicitGrant : AuthorizationGrant(GrantType.IMPLICIT) {
+    override fun toParameters(): MutableMap<String, MutableList<String>> {
+        return mutableMapOf()
+    }
+
+    companion object {
+        fun asTokenRequest(url: HttpUrl, authorizationRequest: AuthorizationRequest): TokenRequest {
+            return TokenRequest(
+                url.toUri(),
+                authorizationRequest.clientID,
+                ImplicitGrant(),
+                authorizationRequest.scope
+            )
+        }
+    }
+}

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
@@ -1,7 +1,10 @@
 package no.nav.security.mock.oauth2.grant
 
+import com.nimbusds.oauth2.sdk.AuthorizationGrant
 import com.nimbusds.oauth2.sdk.AuthorizationRequest
 import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse
+import com.nimbusds.oauth2.sdk.GrantType.IMPLICIT
+import com.nimbusds.oauth2.sdk.TokenRequest
 import com.nimbusds.oauth2.sdk.token.BearerAccessToken
 import no.nav.security.mock.oauth2.extensions.expiresIn
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
@@ -15,13 +18,14 @@ internal class ImplicitGrantHandler(
 ) : GrantHandler {
 
     fun implicitResponse(authorizationRequest: AuthorizationRequest, tokenResponse: OAuth2TokenResponse): AuthorizationSuccessResponse {
+        val accessToken = tokenResponse.toAccessToken()
         return AuthorizationSuccessResponse(
             authorizationRequest.redirectionURI,
             null,
-            BearerAccessToken.parse("${tokenResponse.tokenType} ${tokenResponse.accessToken}"),
+            accessToken,
             authorizationRequest.state,
             null,
-            authorizationRequest.responseMode
+            authorizationRequest.impliedResponseMode()
         )
     }
 
@@ -31,8 +35,8 @@ internal class ImplicitGrantHandler(
         oAuth2TokenCallback: OAuth2TokenCallback
     ): OAuth2TokenResponse {
         val authorizationRequest = request.asAuthorizationRequest()
-        val accessToken = tokenProvider.implicitAccessToken(
-            authorizationRequest,
+        val accessToken = tokenProvider.accessToken(
+            asTokenRequest(request.url, authorizationRequest),
             issuerUrl,
             oAuth2TokenCallback
         )
@@ -42,5 +46,21 @@ internal class ImplicitGrantHandler(
             expiresIn = accessToken.expiresIn(),
             scope = request.asAuthorizationRequest().scope.toString()
         )
+    }
+
+    private fun OAuth2TokenResponse.toAccessToken() =
+        BearerAccessToken.parse("${this.tokenType} ${this.accessToken}")
+
+    private fun asTokenRequest(url: HttpUrl, authorizationRequest: AuthorizationRequest): TokenRequest = TokenRequest(
+        url.toUri(),
+        authorizationRequest.clientID,
+        ImplicitGrant(),
+        authorizationRequest.scope
+    )
+
+    internal class ImplicitGrant : AuthorizationGrant(IMPLICIT) {
+        override fun toParameters(): MutableMap<String, MutableList<String>> {
+            return mutableMapOf()
+        }
     }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
@@ -1,0 +1,46 @@
+package no.nav.security.mock.oauth2.grant
+
+import com.nimbusds.oauth2.sdk.AuthorizationRequest
+import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse
+import com.nimbusds.oauth2.sdk.token.BearerAccessToken
+import no.nav.security.mock.oauth2.extensions.expiresIn
+import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
+import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
+import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
+import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
+import okhttp3.HttpUrl
+
+internal class ImplicitGrantHandler(
+    private val tokenProvider: OAuth2TokenProvider,
+) : GrantHandler {
+
+    fun implicitResponse(authorizationRequest: AuthorizationRequest, tokenResponse: OAuth2TokenResponse): AuthorizationSuccessResponse {
+        return AuthorizationSuccessResponse(
+            authorizationRequest.redirectionURI,
+            null,
+            BearerAccessToken.parse("${tokenResponse.tokenType} ${tokenResponse.accessToken}"),
+            authorizationRequest.state,
+            null,
+            authorizationRequest.responseMode
+        )
+    }
+
+    override fun tokenResponse(
+        request: OAuth2HttpRequest,
+        issuerUrl: HttpUrl,
+        oAuth2TokenCallback: OAuth2TokenCallback
+    ): OAuth2TokenResponse {
+        val authorizationRequest = request.asAuthorizationRequest()
+        val accessToken = tokenProvider.implicitAccessToken(
+            authorizationRequest,
+            issuerUrl,
+            oAuth2TokenCallback
+        )
+        return OAuth2TokenResponse(
+            tokenType = "Bearer",
+            accessToken = accessToken.serialize(),
+            expiresIn = accessToken.expiresIn(),
+            scope = request.asAuthorizationRequest().scope.toString()
+        )
+    }
+}

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
@@ -41,7 +41,7 @@ internal class ImplicitGrantHandler(
             tokenType = "Bearer",
             accessToken = accessToken.serialize(),
             expiresIn = accessToken.expiresIn(),
-            scope = request.asAuthorizationRequest().scope.toString()
+            scope = authorizationRequest.scope?.toString()
         )
     }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/ImplicitGrantHandler.kt
@@ -2,6 +2,7 @@ package no.nav.security.mock.oauth2.grant
 
 import com.nimbusds.oauth2.sdk.AuthorizationRequest
 import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse
+import mu.KotlinLogging
 import no.nav.security.mock.oauth2.extensions.expiresIn
 import no.nav.security.mock.oauth2.extensions.toAccessToken
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
@@ -10,11 +11,14 @@ import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.HttpUrl
 
+private val log = KotlinLogging.logger {}
+
 internal class ImplicitGrantHandler(
     private val tokenProvider: OAuth2TokenProvider,
 ) : GrantHandler {
 
     fun implicitResponse(authorizationRequest: AuthorizationRequest, tokenResponse: OAuth2TokenResponse): AuthorizationSuccessResponse {
+        log.debug("issuing implicit with response type: ${authorizationRequest.responseType}")
         return ConfigurableAuthorizationResponse(
             authorizationRequest,
             tokenResponse.toAccessToken(),

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -1,5 +1,6 @@
 package no.nav.security.mock.oauth2.http
 
+import com.nimbusds.oauth2.sdk.AuthorizationRequest
 import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.TokenRequest
 import com.nimbusds.oauth2.sdk.http.HTTPRequest
@@ -75,6 +76,8 @@ data class OAuth2HttpRequest(
         )
 
     fun asAuthenticationRequest(): AuthenticationRequest = AuthenticationRequest.parse(this.url.toUri())
+
+    fun asAuthorizationRequest(): AuthorizationRequest = AuthorizationRequest.parse(this.url.toUri())
 
     fun type() = when {
         url.isWellKnownUrl() -> WELL_KNOWN

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -101,10 +101,11 @@ fun authenticationSuccess(authorizationSuccessResponse: AuthorizationSuccessResp
                 )
             )
         }
-        else -> OAuth2HttpResponse(
-            headers = Headers.headersOf(HttpHeaderNames.LOCATION.toString(), authorizationSuccessResponse.toURI().toString()),
-            status = 302
-        )
+        else ->
+            OAuth2HttpResponse(
+                headers = Headers.headersOf(HttpHeaderNames.LOCATION.toString(), authorizationSuccessResponse.toURI().toString()),
+                status = 302
+            )
     }
 }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nimbusds.oauth2.sdk.AuthorizationSuccessResponse
 import com.nimbusds.oauth2.sdk.ErrorObject
 import com.nimbusds.oauth2.sdk.ResponseMode
-import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse
 import io.netty.handler.codec.http.HttpHeaderNames
 import no.nav.security.mock.oauth2.templates.TemplateMapper
 import okhttp3.Headers
@@ -89,20 +89,20 @@ fun redirect(location: String, headers: Headers = Headers.headersOf()): OAuth2Ht
 fun notFound(body: String? = null): OAuth2HttpResponse = OAuth2HttpResponse(status = 404, body = body)
 fun methodNotAllowed(): OAuth2HttpResponse = OAuth2HttpResponse(status = 405, body = "method not allowed")
 
-fun authenticationSuccess(authenticationSuccessResponse: AuthenticationSuccessResponse): OAuth2HttpResponse {
-    return when (authenticationSuccessResponse.responseMode) {
+fun authenticationSuccess(authorizationSuccessResponse: AuthorizationSuccessResponse): OAuth2HttpResponse {
+    return when (authorizationSuccessResponse.responseMode) {
         ResponseMode.FORM_POST -> {
             OAuth2HttpResponse(
                 status = 200,
                 body = templateMapper.authorizationCodeResponseHtml(
-                    authenticationSuccessResponse.redirectionURI.toString(),
-                    authenticationSuccessResponse.authorizationCode.value,
-                    authenticationSuccessResponse.state.value
+                    authorizationSuccessResponse.redirectionURI.toString(),
+                    authorizationSuccessResponse.authorizationCode.value,
+                    authorizationSuccessResponse.state.value
                 )
             )
         }
         else -> OAuth2HttpResponse(
-            headers = Headers.headersOf(HttpHeaderNames.LOCATION.toString(), authenticationSuccessResponse.toURI().toString()),
+            headers = Headers.headersOf(HttpHeaderNames.LOCATION.toString(), authorizationSuccessResponse.toURI().toString()),
             status = 302
         )
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -64,7 +64,7 @@ class OAuth2TokenProvider @JvmOverloads constructor(
         null,
         mapOf("acr" to "value1", "abc" to "value2"),
         3600
-    ).sign("default", JOSEObjectType.JWT.type)
+    ).sign(issuerUrl.issuerId(), JOSEObjectType.JWT.type)
 
     fun exchangeAccessToken(
         tokenRequest: TokenRequest,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -7,7 +7,6 @@ import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
-import com.nimbusds.oauth2.sdk.AuthorizationRequest
 import com.nimbusds.oauth2.sdk.TokenRequest
 import no.nav.security.mock.oauth2.extensions.clientIdAsString
 import no.nav.security.mock.oauth2.extensions.issuerId
@@ -52,19 +51,6 @@ class OAuth2TokenProvider @JvmOverloads constructor(
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
     ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.typeHeader(tokenRequest))
-
-    fun implicitAccessToken(
-        authorizationRequest: AuthorizationRequest,
-        issuerUrl: HttpUrl,
-        oAuth2TokenCallback: OAuth2TokenCallback
-    ) = defaultClaims(
-        issuerUrl,
-        "subject",
-        listOf("aud"),
-        null,
-        mapOf("acr" to "value1", "abc" to "value2"),
-        3600
-    ).sign(issuerUrl.issuerId(), JOSEObjectType.JWT.type)
 
     fun exchangeAccessToken(
         tokenRequest: TokenRequest,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -7,6 +7,7 @@ import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.AuthorizationRequest
 import com.nimbusds.oauth2.sdk.TokenRequest
 import no.nav.security.mock.oauth2.extensions.clientIdAsString
 import no.nav.security.mock.oauth2.extensions.issuerId
@@ -51,6 +52,19 @@ class OAuth2TokenProvider @JvmOverloads constructor(
         oAuth2TokenCallback.addClaims(tokenRequest),
         oAuth2TokenCallback.tokenExpiry()
     ).sign(issuerUrl.issuerId(), oAuth2TokenCallback.typeHeader(tokenRequest))
+
+    fun implicitAccessToken(
+        authorizationRequest: AuthorizationRequest,
+        issuerUrl: HttpUrl,
+        oAuth2TokenCallback: OAuth2TokenCallback
+    ) = defaultClaims(
+        issuerUrl,
+        "subject",
+        listOf("aud"),
+        null,
+        mapOf("acr" to "value1", "abc" to "value2"),
+        3600
+    ).sign("default", JOSEObjectType.JWT.type)
 
     fun exchangeAccessToken(
         tokenRequest: TokenRequest,

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
@@ -1,0 +1,53 @@
+package no.nav.security.mock.oauth2.e2e
+
+import io.kotest.assertions.asClue
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.mock.oauth2.testutils.authenticationRequest
+import no.nav.security.mock.oauth2.testutils.client
+import no.nav.security.mock.oauth2.testutils.get
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+
+class ImplicitGrantIntegrationTest {
+
+    private val server = MockOAuth2Server().apply { start() }
+    private val client = client()
+
+    @Test
+    fun `authorized request should return 302 with redirectUri as location and query params access_token, state and token_type`() {
+        client.get(
+            server.authorizationEndpointUrl("default").authenticationRequest(
+                redirectUri = "http://mycallback",
+                state = "mystate",
+                responseType = "token",
+                scope = listOf("some-scope")
+            )
+        ).asClue { response ->
+            response.code shouldBe 302
+
+            response.headers["location"]?.toHttpUrl()?.queryParameter("access_token").shouldNotBeNull()
+
+            response.headers["location"]?.toHttpUrl().asClue {
+                it.toString() shouldStartWith "http://mycallback"
+                it?.queryParameterNames shouldContainExactly setOf("access_token", "state", "token_type")
+                it?.queryParameter("state") shouldBe "mystate"
+            }
+        }
+    }
+
+    @Test
+    fun `implicit grant should return 400 bad request on request when none supported response_type is used`() {
+        client.get(
+            server.authorizationEndpointUrl("default").authenticationRequest(
+                // hybrid grant
+                responseType = "code id_token",
+            )
+        ).asClue { response ->
+            response.code shouldBe 400
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
@@ -1,12 +1,11 @@
 package no.nav.security.mock.oauth2.e2e
 
 import io.kotest.assertions.asClue
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldStartWith
 import no.nav.security.mock.oauth2.MockOAuth2Server
-import no.nav.security.mock.oauth2.testutils.authenticationRequest
+import no.nav.security.mock.oauth2.testutils.authorizationRequest
 import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -18,23 +17,19 @@ class ImplicitGrantIntegrationTest {
     private val client = client()
 
     @Test
-    fun `authorized request should return 302 with redirectUri as location and query params access_token, state and token_type`() {
+    fun `authorized request should return 302 with redirectUri as location and fragment params access_token, state, token_type, expires_in, scope`() {
         client.get(
-            server.authorizationEndpointUrl("default").authenticationRequest(
-                redirectUri = "http://mycallback",
-                state = "mystate",
-                responseType = "token",
-                scope = listOf("some-scope")
-            )
+            server.authorizationEndpointUrl("default").authorizationRequest()
         ).asClue { response ->
             response.code shouldBe 302
-
-            response.headers["location"]?.toHttpUrl()?.queryParameter("access_token").shouldNotBeNull()
-
             response.headers["location"]?.toHttpUrl().asClue {
-                it.toString() shouldStartWith "http://mycallback"
-                it?.queryParameterNames shouldContainExactly setOf("access_token", "state", "token_type")
-                it?.queryParameter("state") shouldBe "mystate"
+                it?.toString() shouldStartWith "http://defaultredirecturi/#"
+                val fragments = it?.encodedFragment
+                fragments.shouldContain("access_token")
+                fragments.shouldContain("state")
+                fragments.shouldContain("token_type")
+                fragments?.shouldContain("expires_in")
+                fragments?.shouldContain("scope")
             }
         }
     }
@@ -42,12 +37,13 @@ class ImplicitGrantIntegrationTest {
     @Test
     fun `implicit grant should return 400 bad request on request when none supported response_type is used`() {
         client.get(
-            server.authorizationEndpointUrl("default").authenticationRequest(
+            server.authorizationEndpointUrl("default").authorizationRequest(
                 // hybrid grant
                 responseType = "code id_token",
             )
         ).asClue { response ->
             response.code shouldBe 400
+            response.body?.string() shouldContain "hybrid grant not supported (yet)"
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.security.mock.oauth2.e2e
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import io.kotest.matchers.string.shouldStartWith
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.testutils.authorizationRequest
@@ -35,6 +36,23 @@ class ImplicitGrantIntegrationTest {
                 fragments.shouldContain("Bearer")
                 fragments.shouldContain("some-scope")
                 fragments.shouldContain("1234")
+            }
+        }
+    }
+
+    @Test
+    fun `authorized request should return 302 with redirectUri as location and fragment without optional param scope`() {
+        client.get(
+            server.authorizationEndpointUrl("default").authorizationRequest(scope = null)
+        ).asClue { response ->
+            response.code shouldBe 302
+            response.headers["location"]?.toHttpUrl().asClue {
+                it?.toString() shouldStartWith "http://defaultredirecturi/#"
+                val fragments = it?.encodedFragment
+                // params
+                fragments.shouldNotContain("scope")
+                // values
+                fragments.shouldNotContain("some-scope")
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/ImplicitGrantIntegrationTest.kt
@@ -25,11 +25,16 @@ class ImplicitGrantIntegrationTest {
             response.headers["location"]?.toHttpUrl().asClue {
                 it?.toString() shouldStartWith "http://defaultredirecturi/#"
                 val fragments = it?.encodedFragment
+                // params
                 fragments.shouldContain("access_token")
                 fragments.shouldContain("state")
                 fragments.shouldContain("token_type")
-                fragments?.shouldContain("expires_in")
-                fragments?.shouldContain("scope")
+                fragments.shouldContain("expires_in")
+                fragments.shouldContain("scope")
+                // values
+                fragments.shouldContain("Bearer")
+                fragments.shouldContain("some-scope")
+                fragments.shouldContain("1234")
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
@@ -101,7 +101,7 @@ internal class AuthorizationCodeHandlerTest {
 
     private fun AuthorizationCodeHandler.retrieveAuthorizationCode(login: Login): String =
         authorizationCodeResponse(
-            authenticationRequest = "http://authorizationendpoint".toHttpUrl().authenticationRequest().asNimbusAuthRequest(),
+            authorizationRequest = "http://authorizationendpoint".toHttpUrl().authenticationRequest().asNimbusAuthRequest(),
             login = login
         ).authorizationCode.value
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/ImplicitHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/ImplicitHandlerTest.kt
@@ -1,0 +1,52 @@
+package no.nav.security.mock.oauth2.grant
+
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.oauth2.sdk.ResponseMode
+import io.kotest.assertions.asClue
+import io.kotest.matchers.shouldBe
+import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
+import no.nav.security.mock.oauth2.testutils.claims
+import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
+import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
+import okhttp3.Headers
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
+
+internal class ImplicitHandlerTest {
+    private val handler = ImplicitGrantHandler(OAuth2TokenProvider())
+
+    @Test
+    fun `authorization implicit response should contain required parameters`() {
+        oauth2HttpRequest().also { request ->
+            val accessToken = handler.tokenResponse(request, "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).apply {
+                val claims = SignedJWT.parse(this.accessToken).claims
+                claims["acr"] shouldBe "value1"
+                claims["abc"] shouldBe "value2"
+            }
+            handler.implicitResponse(request.asAuthorizationRequest(), accessToken).asClue {
+                it.impliedResponseType().impliesImplicitFlow() shouldBe true
+                it.impliedResponseMode() shouldBe ResponseMode.FRAGMENT
+                it.state.toString() shouldBe "mystate"
+                it.redirectionURI.toString() shouldBe "http://redirect"
+                it.toHTTPResponse().statusCode shouldBe 302
+            }
+        }
+    }
+
+    private fun oauth2HttpRequest(
+        redirectUri: String = "http://redirect",
+        scope: String = "openid"
+    ): OAuth2HttpRequest {
+        return OAuth2HttpRequest(
+            headers = Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"),
+            method = "GET",
+            originalUrl = ("http://authorize?" +
+                "response_type=token&" +
+                "client_id=client1&" +
+                "state=mystate&" +
+                "redirect_uri=$redirectUri&" +
+                "scope=$scope").toHttpUrl()
+
+        )
+    }
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/ImplicitHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/ImplicitHandlerTest.kt
@@ -21,8 +21,12 @@ internal class ImplicitHandlerTest {
     fun `authorization implicit response should contain required parameters`() {
         oauth2HttpRequest().also { request ->
 
-            val accessToken = handler.tokenResponse(request, request.url.toIssuerUrl(), DefaultOAuth2TokenCallback()).apply {
-                println(this.accessToken)
+            val accessToken = handler.tokenResponse(
+                request, request.url.toIssuerUrl(),
+                DefaultOAuth2TokenCallback(
+                    claims = mapOf("acr" to "value1", "abc" to "value2")
+                )
+            ).apply {
                 val signedJwt = SignedJWT.parse(this.accessToken)
                 val claims = signedJwt.claims
                 claims["acr"] shouldBe "value1"
@@ -41,17 +45,19 @@ internal class ImplicitHandlerTest {
 
     private fun oauth2HttpRequest(
         redirectUri: String = "http://redirect",
-        scope: String = "openid"
+        scope: String = "some-scope"
     ): OAuth2HttpRequest {
         return OAuth2HttpRequest(
             headers = Headers.headersOf("Content-Type", "application/x-www-form-urlencoded"),
             method = "GET",
-            originalUrl = ("http://myissuer/issuer1/authorize?" +
-                "response_type=token&" +
-                "client_id=client1&" +
-                "state=mystate&" +
-                "redirect_uri=$redirectUri&" +
-                "scope=$scope").toHttpUrl()
+            originalUrl = (
+                "http://myissuer/issuer1/authorize?" +
+                    "response_type=token&" +
+                    "client_id=client1&" +
+                    "state=mystate&" +
+                    "redirect_uri=$redirectUri&" +
+                    "scope=$scope"
+                ).toHttpUrl()
 
         )
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/ImplicitHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/ImplicitHandlerTest.kt
@@ -4,6 +4,7 @@ import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.ResponseMode
 import io.kotest.assertions.asClue
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import no.nav.security.mock.oauth2.extensions.toIssuerUrl
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.testutils.claims
@@ -34,6 +35,7 @@ internal class ImplicitHandlerTest {
                 signedJwt.issuer shouldBe "http://myissuer/issuer1"
             }
             handler.implicitResponse(request.asAuthorizationRequest(), accessToken).asClue {
+                it.accessToken shouldNotBe null
                 it.impliedResponseType().impliesImplicitFlow() shouldBe true
                 it.impliedResponseMode() shouldBe ResponseMode.FRAGMENT
                 it.state.toString() shouldBe "mystate"

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Grant.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Grant.kt
@@ -36,3 +36,17 @@ data class Pkce(
 ) {
     val challenge: CodeChallenge = CodeChallenge.compute(method, verifier)
 }
+
+fun HttpUrl.authorizationRequest(
+    clientId: String = "defautlClient",
+    redirectUri: String = "http://defaultRedirectUri",
+    scope: List<String> = listOf("some-scope"),
+    responseType: String = "token",
+    state: String = "1234",
+): HttpUrl = newBuilder()
+    .addQueryParameter("client_id", clientId)
+    .addQueryParameter("response_type", responseType)
+    .addQueryParameter("redirect_uri", redirectUri)
+    .addQueryParameter("scope", scope.joinToString(" "))
+    .addQueryParameter("state", state)
+    .build()

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Grant.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Grant.kt
@@ -40,13 +40,13 @@ data class Pkce(
 fun HttpUrl.authorizationRequest(
     clientId: String = "defautlClient",
     redirectUri: String = "http://defaultRedirectUri",
-    scope: List<String> = listOf("some-scope"),
+    scope: List<String>? = listOf("some-scope"),
     responseType: String = "token",
     state: String = "1234",
 ): HttpUrl = newBuilder()
     .addQueryParameter("client_id", clientId)
     .addQueryParameter("response_type", responseType)
     .addQueryParameter("redirect_uri", redirectUri)
-    .addQueryParameter("scope", scope.joinToString(" "))
+    .addQueryParameter("scope", scope?.joinToString(" "))
     .addQueryParameter("state", state)
     .build()


### PR DESCRIPTION
I followed the spec. her: https://datatracker.ietf.org/doc/html/rfc6749#section-4.2

In the spec:
```
redirect_uri
         OPTIONAL.  As described in Section 3.1.2.
```

This is not handled by existing implementation of `Authorization code` grant in mock-ouath-server and the spec. dosent say  anything how to handle  `redirect_uri`  when its `optional` so i made an assumption that it can be handle like  in earlier implementation.

AuthorizationCodeHandler:
```java
...
return AuthenticationSuccessResponse(
   authenticationRequest.redirectionURI,
   code,
   null,
   null,
   authenticationRequest.state,
   null,
   authenticationRequest.responseMode
)
...
```