### PR TITLE
Premapped issuer JWKs draft

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -1,18 +1,25 @@
 package no.nav.security.mock.oauth2.token
 
+import com.fasterxml.jackson.databind.node.ObjectNode
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nimbusds.jose.jwk.JWK
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.KeyUse
 import com.nimbusds.jose.jwk.RSAKey
+import mu.KotlinLogging
+import java.io.File
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingDeque
 
+private val log = KotlinLogging.logger { }
+
 open class KeyProvider @JvmOverloads constructor(
-    private val initialKeys: List<RSAKey> = keysFromFile(INITIAL_KEYS_FILE)
+    private val initialKeys: List<RSAKey> = keysFromFile(INITIAL_KEYS_FILE),
+    private val initialMappedKeys: Map<String, RSAKey> = mappedKeysFromFile()
 ) {
-    private val signingKeys: ConcurrentHashMap<String, RSAKey> = ConcurrentHashMap()
 
     private val generator = KeyPairGenerator.getInstance("RSA").apply { this.initialize(2048) }
 
@@ -22,21 +29,15 @@ open class KeyProvider @JvmOverloads constructor(
         }
     }
 
+    private val signingKeys: ConcurrentHashMap<String, RSAKey> = ConcurrentHashMap<String, RSAKey>().apply {
+        this.putAll(initialMappedKeys)
+    }
+
     fun signingKey(keyId: String): RSAKey = signingKeys.computeIfAbsent(keyId) { keyFromDequeOrNew(keyId) }
 
     private fun keyFromDequeOrNew(keyId: String): RSAKey = keyDeque.poll()?.let {
         RSAKey.Builder(it).keyID(keyId).build()
     } ?: generator.generateRSAKey(keyId)
-
-    private fun KeyPairGenerator.generateRSAKey(keyId: String): RSAKey =
-        generateKeyPair()
-            .let {
-                RSAKey.Builder(it.public as RSAPublicKey)
-                    .privateKey(it.private as RSAPrivateKey)
-                    .keyUse(KeyUse.SIGNATURE)
-                    .keyID(keyId)
-                    .build()
-            }
 
     companion object {
         const val INITIAL_KEYS_FILE = "/mock-oauth2-server-keys.json"
@@ -48,5 +49,59 @@ open class KeyProvider @JvmOverloads constructor(
             }
             return emptyList()
         }
+
+        /**
+         * Expecting a json file with content like `{"issuer1": <JWK>, "issuer2": null, "issuer3: <JWK> }` etc...
+         * if the issuer entry has value null, then generate a key which is also logged.
+         */
+        private fun mappedKeysFromFile(explicitFilename: String? = null): Map<String, RSAKey> {
+            val om = jacksonObjectMapper()
+            val generator = KeyPairGenerator.getInstance("RSA").apply { this.initialize(2048) }
+            val out = mutableMapOf<String, RSAKey>()
+            val environmentFilename = System.getenv()["PREDEFINED_ISSUER_JWKS"] ?: System.getProperty("PREDEFINED_ISSUER_JWKS")
+
+            val prioritizedFile: File = when {
+                (explicitFilename != null) -> File(explicitFilename)
+                (environmentFilename != null) -> File(environmentFilename)
+                (File("iss2jwk.json").exists()) -> {
+                    log.debug("Found default config file for predefined issuer JWKs")
+                    File("iss2jwk.json")
+                }
+                else -> return emptyMap()
+            }
+            try {
+                val predefinedIssuerJwkConfig = om.readValue(prioritizedFile, ObjectNode::class.java)
+                predefinedIssuerJwkConfig.fields().forEach {
+                    val issuerName = it.key
+                    val jwkString = it.value
+                    if (!jwkString.isNull) {
+                        try {
+                            out.put(issuerName, JWK.parse(jwkString.toString()).toRSAKey())
+                        } catch(ex: Exception){
+                            throw RuntimeException("Error when parsing JWK for issuer '${issuerName}'",ex)
+                        }
+                    } else {
+                        val generated = generator.generateRSAKey(issuerName).apply {
+                            val prettyJson = om.writerWithDefaultPrettyPrinter().writeValueAsString(this.toJSONObject())
+                            log.debug("Created JWK for issuer '${issuerName}' => \n${prettyJson}\n")
+                        }
+                        out.put(issuerName, generated)
+                    }
+                }
+            } catch (ex: Exception) {
+                throw IllegalStateException("Could not add premapped issuer JWKs from file ${prioritizedFile.absolutePath}", ex)
+            }
+            return out.toMap()
+        }
     }
 }
+
+private fun KeyPairGenerator.generateRSAKey(keyId: String): RSAKey =
+    generateKeyPair()
+        .let {
+            RSAKey.Builder(it.public as RSAPublicKey)
+                .privateKey(it.private as RSAPrivateKey)
+                .keyUse(KeyUse.SIGNATURE)
+                .keyID(keyId)
+                .build()
+        }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -76,14 +76,18 @@ open class KeyProvider @JvmOverloads constructor(
                     val jwkString = it.value
                     if (!jwkString.isNull) {
                         try {
-                            out.put(issuerName, JWK.parse(jwkString.toString()).toRSAKey())
-                        } catch(ex: Exception){
-                            throw RuntimeException("Error when parsing JWK for issuer '${issuerName}'",ex)
+                            val parsedJWK = JWK.parse(jwkString.toString()).toRSAKey()
+                            if(!parsedJWK.keyID.equals(issuerName)){
+                                throw RuntimeException("Error when parsing JWK for issuer '$issuerName'. kid must match issuer name")
+                            }
+                            out[issuerName] = parsedJWK
+                        } catch (ex: Exception) {
+                            throw RuntimeException("Error when parsing JWK for issuer '$issuerName'", ex)
                         }
                     } else {
                         val generated = generator.generateRSAKey(issuerName).apply {
                             val prettyJson = om.writerWithDefaultPrettyPrinter().writeValueAsString(this.toJSONObject())
-                            log.debug("Created JWK for issuer '${issuerName}' => \n${prettyJson}\n")
+                            log.debug("Created JWK for issuer '$issuerName' => \n${prettyJson}\n")
                         }
                         out.put(issuerName, generated)
                     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -77,7 +77,7 @@ open class KeyProvider @JvmOverloads constructor(
                     if (!jwkString.isNull) {
                         try {
                             val parsedJWK = JWK.parse(jwkString.toString()).toRSAKey()
-                            if(!parsedJWK.keyID.equals(issuerName)){
+                            if (!parsedJWK.keyID.equals(issuerName)) {
                                 throw RuntimeException("Error when parsing JWK for issuer '$issuerName'. kid must match issuer name")
                             }
                             out[issuerName] = parsedJWK

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyProviderTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/KeyProviderTest.kt
@@ -71,29 +71,31 @@ internal class KeyProviderTest {
     }
 
     @Test
-    fun `reading premapped issuer jwks config file behaves as expected`(){
+    fun `reading premapped issuer jwks config file behaves as expected`() {
         val jsonFile = "./src/test/resources/" + "premapped_issuer_jwks_testfile.json"
         System.setProperty("PREDEFINED_ISSUER_JWKS", jsonFile)
 
         val jsonObj = jacksonObjectMapper().readValue(File(jsonFile), ObjectNode::class.java)
 
         val keyProvider = KeyProvider()
-        val issuers = listOf("aad","other3")
-        for(iss in issuers){
+        val issuers = listOf("aad", "other3")
+        for (iss in issuers) {
             val actual = keyProvider.signingKey(iss)
             val expected = JWK.parse(jsonObj.get(iss).toString()).toRSAKey()
-            assertEquals(expected,actual)
+            assertEquals(expected, actual)
         }
+        System.clearProperty("PREDEFINED_ISSUER_JWKS")
     }
 
     @Test
-    fun `reading invalid premapped issuer jwks config file fails`(){
+    fun `reading invalid premapped issuer jwks config file fails`() {
         val jsonFile = "./src/test/resources/" + "premapped_issuer_jwks_testfile_invalid.json"
         System.setProperty("PREDEFINED_ISSUER_JWKS", jsonFile)
 
-        shouldThrow<IllegalStateException>{
+        shouldThrow<IllegalStateException> {
             KeyProvider()
         }
+        System.clearProperty("PREDEFINED_ISSUER_JWKS")
     }
 
     private fun initialPublicKeys(): List<RSAPublicKey> =

--- a/src/test/resources/premapped_issuer_jwks_testfile.json
+++ b/src/test/resources/premapped_issuer_jwks_testfile.json
@@ -1,0 +1,31 @@
+{
+  "aad": {
+    "p": "8X4E3UUItsFp4JSzLVBvDz7VKZAvQTbngQfvIRokECLdsP--1YGkniit-e9KHR8UtVI3h-cqMmHvffHoqwOdKoxi5BViuwmqCdIfjBvpfQB3PZxOEAFojiRG0apxnXtmxUKG3PIIsFGXG8YhHwLIqwTvwaKr1BF3g6qW2pSzFFs",
+    "kty": "RSA",
+    "q": "3YFMc2Ux4sFcBHqT440beIBmXbEeUZ3jc-728PFXGZRVeTNn9HZSascgO6nw9iECz-jRQwTX4P9RIAnWm782AV5QIGXmz3t-4ssimLHtP9jkyhqTDMmuUUv1QKhdD2p4q_uzbrkx4A3OMphgGDbLe4UKBA-9X10BozoRFXawNds",
+    "d": "EFVtvj1zJ5ixPHVH-4bzDNQK_WJyi8RkxkbVFXmfMdtylh3tWfaNRnuKjiwlCHWT7x0Asof4SYY9YAPvoaq8g79zp4sRL_XmNawLk9QRi0hHHXowwlVK39qQHZ15Q8Hs3s3VDXx6NlVqWBFjTBz2eX-2vwesvPjPQUd2iCXRz8UXtsKRuToE_ddAFLC_Gcz_yPSQCFfyptPhBCPVsI6opsdK_SELuGspvI3ux2Gbq5aWGaByWo5-2NpPfXdiEPcY0mREKfe3kQU0Wa5-vqYA43ekpFaCKSsj-vmmhkP0FwQxBtVs_CVxRfgzyn1_mF2oZsPuvUeJXbHFF-PdjBmz7Q",
+    "e": "AQAB",
+    "use": "sig",
+    "kid": "initialkey-2",
+    "qi": "5OHgZtRG6CecHV-2AUlRZtHraN_G3nftrMAGuczh97RdjlEUxia_LkQqc_OUJf8M_57I5WZ4z2H7u1JVzscM3D7nFKJLq2JoW5kc2zffYhZm83mcTWyvQSf6WPvmqxqX2TZr_JFBLn0_33DQUZwOj4tAmvpXjYFCqWXbNjZxEs4",
+    "dp": "669a3fzXAU4IoCdgK5R5n35qGbNfex0zmYl9x2e01I7CoFEpFUT-vWDkUq5IPd2snz4LdjaUxzEvxFJJCkZvqCv1A7cfcX2AFy-cnGhNWzMOLPIUeah2O2uKNmxLkC_0YAaKiq4o7rPibzfR8WsNH2Ok_u1dF46ofrcJnXBMyks",
+    "dq": "FhPBDu9THYqwJTIic1epGUWS7lus7e2SsgdrTXCAgegq7L2W6uKwLDxUlh3GCoIXyakm0ks1SROpfkv8u-E-_LvtuIzviFaCuxAMDrQNNYPkqdAkP-4KFchAVYVyYQr3pAyeQbbrpa06lAhj64XqmhEUgnsfINYgR6iN81m1Dmk",
+    "n": "0PPC0byb9f-Kueq8B733sZnANXDHyy2M5qUr1vWW733l_lOf2dFKDu6csaGEALro_39EFjhoad1D7Ebw1srj5APElaX9QMQxjK4pEdJlNU9SygwBObgAqCxfWmBjNBQ4NBrG8wi61MG4aoYwi-5W-N0VLL6tOxe_V6JyA4P4e-EzrlRJm9_dHT6ev3c6KyaRcGVnOBuArj3uhOh15-tbjuux8P30kR6RytxRWRZzAQqpkekpBFYYvoFyP3N_WGU5ruOEUYF8KloDmFqANSpqXvUyI3kl-McTtqzH0BuZG6fG8bH3ZZdH1fM2BJ8z0fO7n24HhNn3lAIPo8q9OPlA2Q"
+  },
+  "tokenx": null,
+  "other": null,
+  "other2": null,
+  "other3" : {
+    "p" : "xFU_V91nORjVy4lvtOabcxN6H1-Z28ClhrT51XwwLHNdUAN_MsqaGCrdTlpUj2b5zzyUbL1GZ5MWHxRO8wPby2yyqYWJE9H9gdpqxnMkBK5M5C4YeMpSTdT483xT0VS3quLMx34P-hrb09gehyh0Vfbq6htChJoQ7gajGEQ7Ltc",
+    "kty" : "RSA",
+    "q" : "7xzC8t2RL5zEs8sBShB0Xjf98M2tB8kOjYJw5HT1OjviEGbnSb6slFOikiUgK_8mDoLOrBTHG1Zh19-tzslMefUxDSzDrcmxrpmLXSNM19t-bNPJ1sMZbtukcn4maiDTXVbUfXCVYnei-AmdiKcJW8HBraIlTGnCIhB19fYMBPU",
+    "d" : "B38HVmCFZm9eq0cwSG7x4W-bZxJX-KkL5ejVLnIXbKYa2Slxm8gaUj2A1GB4ZjDGIwhzakvuiJU2s1kocHSBJsVYL5tHRSKmuH-gFT4FXyynbCZV2h_d_yJO1CyIjjGCWUqnCFFYLWVr7EE_9bC6dZWX4tL953PS8Mr0wUek7iDfEYyqmBHgzyXu--PnpXs8W7AYDOg9LFa9RFddD4_CRt-g8DvDnDTJCu9DmN1hRZbNvicOV_mk7SCr5_XEaKMas2mgkOsnhnE8_j-kY6SYsSXZvgvlN-lIc4ReGW7Rl5palJN5QUq7PSS_t5X0Ulqz1tf5dLlx_2ctPRvOWQDQSQ",
+    "e" : "AQAB",
+    "use" : "sig",
+    "kid" : "other3",
+    "qi" : "G2gr4h9nKPtIOw-x9iqZizjltTksozB5q57dSydzWgEQrl4im8l_cI06qgqAzUI_uiMHw-1HpWxrLRsAOnTtwa0mdd6HNBZKnEzNVA_V0EFoIpruNkr-3A6z0RgpIivU_mBrerlNtvhReBJpvzvzFVSFTquu522yko-mR4s6KB8",
+    "dp" : "DXmUWWF2vjJ4KfoK0q2pKaLClPioxK5aLf6pzv8xBzv7wYwb5M6G-PWoLsKAXz9AEfskbLoo5N7xe7yXFpLDORkCwiPKHrQg5BKrlWc9p5yW5mpLf67TK0hctclor0tTN8VNLLv4OMAzKj0BC2G5alUCFoM8c4FnfA60juvP7A0",
+    "dq" : "BV3w5kCg5J-xLpPs6HusEP1Svtfu_VC--eAmpooVgwQbE-EradVUzFOAP6WDrlkgwoyfFO-2dF-g_JZxsUWFaOte-Xu6vKjdSxz5KtMDA4lSsiCi1CY26O0XKNa6CAHKnLq5NEOVpssmpkiY95tAM4YK0dnk2m05RUh3TVkDdg0",
+    "n" : "t2Gk-NHS_OuPfpnOdv3VCQdwJ4lqpKXxLy4RUpaWSbnP9bUn9v1uBSSzclDqkAXDx61KIQAsxTUoSJxQCmkThSjlDEabCOEe-aFz_qwQKwDqxHG22LLlb1quWAsniPDbqz15jAdPSdP6bT1F8VmNXDfyR4-xfmW2GNXQ0R6AymEuqO3zptpL8u1b3GjswBrKmTNtcQ4ikNynSbqOQ8lc_4Hd9zl2tFCiuG_fvueCom3HGJ58ZR2OQvfTFWbEIihNplclTy3u9a1qT-a4NSlSDNsrKBKXxpzLAScoCanSk6ODM51uSVRIlrLcu2JrYnYp49k_OW4xOjayFp_WBXMvww"
+  }
+}

--- a/src/test/resources/premapped_issuer_jwks_testfile.json
+++ b/src/test/resources/premapped_issuer_jwks_testfile.json
@@ -6,7 +6,7 @@
     "d": "EFVtvj1zJ5ixPHVH-4bzDNQK_WJyi8RkxkbVFXmfMdtylh3tWfaNRnuKjiwlCHWT7x0Asof4SYY9YAPvoaq8g79zp4sRL_XmNawLk9QRi0hHHXowwlVK39qQHZ15Q8Hs3s3VDXx6NlVqWBFjTBz2eX-2vwesvPjPQUd2iCXRz8UXtsKRuToE_ddAFLC_Gcz_yPSQCFfyptPhBCPVsI6opsdK_SELuGspvI3ux2Gbq5aWGaByWo5-2NpPfXdiEPcY0mREKfe3kQU0Wa5-vqYA43ekpFaCKSsj-vmmhkP0FwQxBtVs_CVxRfgzyn1_mF2oZsPuvUeJXbHFF-PdjBmz7Q",
     "e": "AQAB",
     "use": "sig",
-    "kid": "initialkey-2",
+    "kid": "aad",
     "qi": "5OHgZtRG6CecHV-2AUlRZtHraN_G3nftrMAGuczh97RdjlEUxia_LkQqc_OUJf8M_57I5WZ4z2H7u1JVzscM3D7nFKJLq2JoW5kc2zffYhZm83mcTWyvQSf6WPvmqxqX2TZr_JFBLn0_33DQUZwOj4tAmvpXjYFCqWXbNjZxEs4",
     "dp": "669a3fzXAU4IoCdgK5R5n35qGbNfex0zmYl9x2e01I7CoFEpFUT-vWDkUq5IPd2snz4LdjaUxzEvxFJJCkZvqCv1A7cfcX2AFy-cnGhNWzMOLPIUeah2O2uKNmxLkC_0YAaKiq4o7rPibzfR8WsNH2Ok_u1dF46ofrcJnXBMyks",
     "dq": "FhPBDu9THYqwJTIic1epGUWS7lus7e2SsgdrTXCAgegq7L2W6uKwLDxUlh3GCoIXyakm0ks1SROpfkv8u-E-_LvtuIzviFaCuxAMDrQNNYPkqdAkP-4KFchAVYVyYQr3pAyeQbbrpa06lAhj64XqmhEUgnsfINYgR6iN81m1Dmk",

--- a/src/test/resources/premapped_issuer_jwks_testfile_invalid.json
+++ b/src/test/resources/premapped_issuer_jwks_testfile_invalid.json
@@ -1,0 +1,31 @@
+{
+  "aad": {
+    "p": "8X4E3UUItsFp4JSzLVBvDz7VKZAvQTbngQfvIRokECLdsP--1YGkniit-e9KHR8UtVI3h-cqMmHvffHoqwOdKoxi5BViuwmqCdIfjBvpfQB3PZxOEAFojiRG0apxnXtmxUKG3PIIsFGXG8YhHwLIqwTvwaKr1BF3g6qW2pSzFFs",
+    "kty": "RSA",
+    "q": "3YFMc2Ux4sFcBHqT440beIBmXbEeUZ3jc-728PFXGZRVeTNn9HZSascgO6nw9iECz-jRQwTX4P9RIAnWm782AV5QIGXmz3t-4ssimLHtP9jkyhqTDMmuUUv1QKhdD2p4q_uzbrkx4A3OMphgGDbLe4UKBA-9X10BozoRFXawNds",
+    "d": "EFVtvj1zJ5ixPHVH-4bzDNQK_WJyi8RkxkbVFXmfMdtylh3tWfaNRnuKjiwlCHWT7x0Asof4SYY9YAPvoaq8g79zp4sRL_XmNawLk9QRi0hHHXowwlVK39qQHZ15Q8Hs3s3VDXx6NlVqWBFjTBz2eX-2vwesvPjPQUd2iCXRz8UXtsKRuToE_ddAFLC_Gcz_yPSQCFfyptPhBCPVsI6opsdK_SELuGspvI3ux2Gbq5aWGaByWo5-2NpPfXdiEPcY0mREKfe3kQU0Wa5-vqYA43ekpFaCKSsj-vmmhkP0FwQxBtVs_CVxRfgzyn1_mF2oZsPuvUeJXbHFF-PdjBmz7Q",
+    "e": "AQAB",
+    "use": "sig",
+    "kid": "initialkey-2",
+    "qi": "5OHgZtRG6CecHV-2AUlRZtHraN_G3nftrMAGuczh97RdjlEUxia_LkQqc_OUJf8M_57I5WZ4z2H7u1JVzscM3D7nFKJLq2JoW5kc2zffYhZm83mcTWyvQSf6WPvmqxqX2TZr_JFBLn0_33DQUZwOj4tAmvpXjYFCqWXbNjZxEs4",
+    "dp": "669a3fzXAU4IoCdgK5R5n35qGbNfex0zmYl9x2e01I7CoFEpFUT-vWDkUq5IPd2snz4LdjaUxzEvxFJJCkZvqCv1A7cfcX2AFy-cnGhNWzMOLPIUeah2O2uKNmxLkC_0YAaKiq4o7rPibzfR8WsNH2Ok_u1dF46ofrcJnXBMyks",
+    "dq": "FhPBDu9THYqwJTIic1epGUWS7lus7e2SsgdrTXCAgegq7L2W6uKwLDxUlh3GCoIXyakm0ks1SROpfkv8u-E-_LvtuIzviFaCuxAMDrQNNYPkqdAkP-4KFchAVYVyYQr3pAyeQbbrpa06lAhj64XqmhEUgnsfINYgR6iN81m1Dmk",
+    "nINVALID": "0PPC0byb9f-Kueq8B733sZnANXDHyy2M5qUr1vWW733l_lOf2dFKDu6csaGEALro_39EFjhoad1D7Ebw1srj5APElaX9QMQxjK4pEdJlNU9SygwBObgAqCxfWmBjNBQ4NBrG8wi61MG4aoYwi-5W-N0VLL6tOxe_V6JyA4P4e-EzrlRJm9_dHT6ev3c6KyaRcGVnOBuArj3uhOh15-tbjuux8P30kR6RytxRWRZzAQqpkekpBFYYvoFyP3N_WGU5ruOEUYF8KloDmFqANSpqXvUyI3kl-McTtqzH0BuZG6fG8bH3ZZdH1fM2BJ8z0fO7n24HhNn3lAIPo8q9OPlA2Q"
+  },
+  "tokenx": null,
+  "other": null,
+  "other2": null,
+  "other3" : {
+    "p" : "xFU_V91nORjVy4lvtOabcxN6H1-Z28ClhrT51XwwLHNdUAN_MsqaGCrdTlpUj2b5zzyUbL1GZ5MWHxRO8wPby2yyqYWJE9H9gdpqxnMkBK5M5C4YeMpSTdT483xT0VS3quLMx34P-hrb09gehyh0Vfbq6htChJoQ7gajGEQ7Ltc",
+    "kty" : "RSA",
+    "q" : "7xzC8t2RL5zEs8sBShB0Xjf98M2tB8kOjYJw5HT1OjviEGbnSb6slFOikiUgK_8mDoLOrBTHG1Zh19-tzslMefUxDSzDrcmxrpmLXSNM19t-bNPJ1sMZbtukcn4maiDTXVbUfXCVYnei-AmdiKcJW8HBraIlTGnCIhB19fYMBPU",
+    "d" : "B38HVmCFZm9eq0cwSG7x4W-bZxJX-KkL5ejVLnIXbKYa2Slxm8gaUj2A1GB4ZjDGIwhzakvuiJU2s1kocHSBJsVYL5tHRSKmuH-gFT4FXyynbCZV2h_d_yJO1CyIjjGCWUqnCFFYLWVr7EE_9bC6dZWX4tL953PS8Mr0wUek7iDfEYyqmBHgzyXu--PnpXs8W7AYDOg9LFa9RFddD4_CRt-g8DvDnDTJCu9DmN1hRZbNvicOV_mk7SCr5_XEaKMas2mgkOsnhnE8_j-kY6SYsSXZvgvlN-lIc4ReGW7Rl5palJN5QUq7PSS_t5X0Ulqz1tf5dLlx_2ctPRvOWQDQSQ",
+    "e" : "AQAB",
+    "use" : "sig",
+    "kid" : "other3",
+    "qi" : "G2gr4h9nKPtIOw-x9iqZizjltTksozB5q57dSydzWgEQrl4im8l_cI06qgqAzUI_uiMHw-1HpWxrLRsAOnTtwa0mdd6HNBZKnEzNVA_V0EFoIpruNkr-3A6z0RgpIivU_mBrerlNtvhReBJpvzvzFVSFTquu522yko-mR4s6KB8",
+    "dp" : "DXmUWWF2vjJ4KfoK0q2pKaLClPioxK5aLf6pzv8xBzv7wYwb5M6G-PWoLsKAXz9AEfskbLoo5N7xe7yXFpLDORkCwiPKHrQg5BKrlWc9p5yW5mpLf67TK0hctclor0tTN8VNLLv4OMAzKj0BC2G5alUCFoM8c4FnfA60juvP7A0",
+    "dq" : "BV3w5kCg5J-xLpPs6HusEP1Svtfu_VC--eAmpooVgwQbE-EradVUzFOAP6WDrlkgwoyfFO-2dF-g_JZxsUWFaOte-Xu6vKjdSxz5KtMDA4lSsiCi1CY26O0XKNa6CAHKnLq5NEOVpssmpkiY95tAM4YK0dnk2m05RUh3TVkDdg0",
+    "n" : "t2Gk-NHS_OuPfpnOdv3VCQdwJ4lqpKXxLy4RUpaWSbnP9bUn9v1uBSSzclDqkAXDx61KIQAsxTUoSJxQCmkThSjlDEabCOEe-aFz_qwQKwDqxHG22LLlb1quWAsniPDbqz15jAdPSdP6bT1F8VmNXDfyR4-xfmW2GNXQ0R6AymEuqO3zptpL8u1b3GjswBrKmTNtcQ4ikNynSbqOQ8lc_4Hd9zl2tFCiuG_fvueCom3HGJ58ZR2OQvfTFWbEIihNplclTy3u9a1qT-a4NSlSDNsrKBKXxpzLAScoCanSk6ODM51uSVRIlrLcu2JrYnYp49k_OW4xOjayFp_WBXMvww"
+  }
+}

--- a/src/test/resources/premapped_issuer_jwks_testfile_invalid.json
+++ b/src/test/resources/premapped_issuer_jwks_testfile_invalid.json
@@ -6,7 +6,7 @@
     "d": "EFVtvj1zJ5ixPHVH-4bzDNQK_WJyi8RkxkbVFXmfMdtylh3tWfaNRnuKjiwlCHWT7x0Asof4SYY9YAPvoaq8g79zp4sRL_XmNawLk9QRi0hHHXowwlVK39qQHZ15Q8Hs3s3VDXx6NlVqWBFjTBz2eX-2vwesvPjPQUd2iCXRz8UXtsKRuToE_ddAFLC_Gcz_yPSQCFfyptPhBCPVsI6opsdK_SELuGspvI3ux2Gbq5aWGaByWo5-2NpPfXdiEPcY0mREKfe3kQU0Wa5-vqYA43ekpFaCKSsj-vmmhkP0FwQxBtVs_CVxRfgzyn1_mF2oZsPuvUeJXbHFF-PdjBmz7Q",
     "e": "AQAB",
     "use": "sig",
-    "kid": "initialkey-2",
+    "kid": "aad",
     "qi": "5OHgZtRG6CecHV-2AUlRZtHraN_G3nftrMAGuczh97RdjlEUxia_LkQqc_OUJf8M_57I5WZ4z2H7u1JVzscM3D7nFKJLq2JoW5kc2zffYhZm83mcTWyvQSf6WPvmqxqX2TZr_JFBLn0_33DQUZwOj4tAmvpXjYFCqWXbNjZxEs4",
     "dp": "669a3fzXAU4IoCdgK5R5n35qGbNfex0zmYl9x2e01I7CoFEpFUT-vWDkUq5IPd2snz4LdjaUxzEvxFJJCkZvqCv1A7cfcX2AFy-cnGhNWzMOLPIUeah2O2uKNmxLkC_0YAaKiq4o7rPibzfR8WsNH2Ok_u1dF46ofrcJnXBMyks",
     "dq": "FhPBDu9THYqwJTIic1epGUWS7lus7e2SsgdrTXCAgegq7L2W6uKwLDxUlh3GCoIXyakm0ks1SROpfkv8u-E-_LvtuIzviFaCuxAMDrQNNYPkqdAkP-4KFchAVYVyYQr3pAyeQbbrpa06lAhj64XqmhEUgnsfINYgR6iN81m1Dmk",


### PR DESCRIPTION
This attempts to allow the creation of signed but customized tokens in tests, giving more control per test case, even with the mock-oauth2-server running.

This versus having to bootstrap the application under test by stubbing oauth2 endpoints manually.

An alternative not explored here is having additional endpoints in the mock-oauth2-server for retrieving the full or private JWK.