### PR TITLE
Added <issuer>/testutils/* paths

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/HttpUrlExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/HttpUrlExtensions.kt
@@ -23,6 +23,8 @@ object OAuth2Endpoints {
     const val USER_INFO = "/userinfo"
     const val DEBUGGER = "/debugger"
     const val DEBUGGER_CALLBACK = "/debugger/callback"
+    const val TESTUTILS_JWKS = "/testutils/fulljwkssecret"
+    const val TESTUTILS_SIGN = "/testutils/signclaims"
 
     val all = listOf(
         OAUTH2_WELL_KNOWN,
@@ -33,7 +35,9 @@ object OAuth2Endpoints {
         JWKS,
         USER_INFO,
         DEBUGGER,
-        DEBUGGER_CALLBACK
+        DEBUGGER_CALLBACK,
+        TESTUTILS_JWKS,
+        TESTUTILS_SIGN
     )
 }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -145,4 +145,9 @@ class OAuth2TokenProvider @JvmOverloads constructor(
         builder.addClaims(additionalClaims)
         builder.build()
     }
+
+    fun fullJwkSet(issuerId: String): JWKSet {
+        val jwk = keyProvider.signingKey(issuerId)
+        return JWKSet(jwk)
+    }
 }


### PR DESCRIPTION
There are two testutils endpoints added.

GET issuer/testutils/fulljwkssecret
gives you the full backing JWK

POST issuer/testutils/signclaims
gives you back a Base64 encoded signed token with the
provided claims and expiry time. The endpoint expects JSON
with a 'claims' field, and an optional 'expiry' field
that contains a string compatible with the java.time.Duration
format, like 'PT1H'

Both endpoints are introduced to make it possible to
create valid, custom tokens for testing purposes.