### PR TITLE
Parse host:port in host header for proxied connections

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -33,6 +33,7 @@ import no.nav.security.mock.oauth2.http.RequestType.WELL_KNOWN
 import no.nav.security.mock.oauth2.missingParameter
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import java.net.URI
 
 data class OAuth2HttpRequest(
     val headers: Headers,
@@ -109,11 +110,15 @@ data class OAuth2HttpRequest(
         val proto = this.headers["x-forwarded-proto"]
         val port = this.headers["x-forwarded-port"]
         return if (hostheader != null && proto != null) {
+            val hostUri = URI(null, hostheader, null, null, null).parseServerAuthority()
+            val hostFromHostHeader = hostUri.host
+            val portFromHostHeader = hostUri.port
+
             HttpUrl.Builder()
                 .scheme(proto)
-                .host(hostheader)
+                .host(hostFromHostHeader)
                 .apply {
-                    port?.toInt()?.let { port(it) }
+                    port?.toInt()?.let { port(it) } ?: port(portFromHostHeader)
                 }
                 .encodedPath(originalUrl.encodedPath)
                 .query(originalUrl.query).build()

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -28,6 +28,34 @@ internal class OAuth2HttpRequestTest {
             originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req2.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io:444/mypath?query=1"
+
+        // host header has host:port and x-forwarded-port is set
+        val req3 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host",
+                "fakedings.nais.io:666",
+                "x-forwarded-proto",
+                "https",
+                "x-forwarded-port",
+                "444"
+            ),
+            method = "GET",
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req3.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io:444/mypath?query=1"
+
+        // host header has host:port and no x-forwarded-port
+        val req4 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host",
+                "fakedings.nais.io:666",
+                "x-forwarded-proto",
+                "https"
+            ),
+            method = "GET",
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req4.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io:666/mypath?query=1"
     }
 
     @Test


### PR DESCRIPTION
In a scenario where the `Host` header arrives with hostname and port, on a proxied connection (with `x-forwarded-proto` also set), there is an exception thrown.

I.e.
```
curl -vvv http://localhost:8080/default/.well-known/openid-configuration --header "Host: localhost:8080" --header "x-forwarded-proto: http"
```

Generates this error:
```
java.lang.IllegalArgumentException: unexpected host: localhost:8080
	at okhttp3.HttpUrl$Builder.host(HttpUrl.kt:961)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRequest.proxyAwareUrl$mock_oauth2_server(OAuth2HttpRequest.kt:114)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRequest.getUrl(OAuth2HttpRequest.kt:43)
	at no.nav.security.mock.oauth2.http.OAuth2HttpRouterKt$routeFromPathAndMethod$1.matchPath(OAuth2HttpRouter.kt:117)
```

This PR parses host/port form then host header before building the URI via the HttpUrl.Builder.