### PR TITLE
feat: allow requests with credentials for requests of different origin

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -4,6 +4,7 @@ import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.TokenRequest
 import com.nimbusds.oauth2.sdk.http.HTTPRequest
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
+import io.netty.handler.codec.http.HttpHeaderNames
 import no.nav.security.mock.oauth2.extensions.clientAuthentication
 import no.nav.security.mock.oauth2.extensions.isAuthorizationEndpointUrl
 import no.nav.security.mock.oauth2.extensions.isDebuggerCallbackUrl
@@ -109,6 +110,8 @@ data class OAuth2HttpRequest(
             jwksUri = this.proxyAwareUrl().toJwksUrl().toString(),
             userInfoEndpoint = this.proxyAwareUrl().toUserInfoUrl().toString()
         )
+
+    fun origin() = this.headers[HttpHeaderNames.ORIGIN.toString()]
 
     internal fun proxyAwareUrl(): HttpUrl {
         val hostheader = this.headers["host"]

--- a/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
@@ -23,7 +23,7 @@ internal fun Route.Builder.userInfo(tokenProvider: OAuth2TokenProvider) =
     get(USER_INFO) {
         log.debug("received request to userinfo endpoint, returning claims from token")
         val claims = it.verifyBearerToken(tokenProvider).claims
-        json(claims)
+        json(claims, it.origin())
     }
 
 private fun OAuth2HttpRequest.verifyBearerToken(tokenProvider: OAuth2TokenProvider): JWTClaimsSet {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
@@ -8,6 +8,7 @@ import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
 import no.nav.security.mock.oauth2.testutils.options
 import no.nav.security.mock.oauth2.testutils.tokenRequest
+import no.nav.security.mock.oauth2.testutils.withHeaders
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.withMockOAuth2Server
 import org.junit.jupiter.api.Test
@@ -16,56 +17,64 @@ class CorsHeadersIntegrationTest {
     private val client = client()
 
     @Test
-    fun `preflight response should allow all origin, all methods and all headers`() {
+    fun `preflight response with origin should allow origin, all methods and all headers`() {
         withMockOAuth2Server {
-            client.options(this.baseUrl()).asClue {
-                it.code shouldBe 200
-                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
-                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString()] shouldBe "*"
-                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString()] shouldBe "*"
-            }
+            client
+                .withHeaders(mapOf(HttpHeaderNames.ORIGIN.toString() to "http://somehost/"))
+                .options(this.baseUrl()).asClue {
+                    it.code shouldBe 200
+                    it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "http://somehost/"
+                    it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_METHODS.toString()] shouldBe "*"
+                    it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_HEADERS.toString()] shouldBe "*"
+                }
         }
     }
 
     @Test
-    fun `wellknown response should allow all origins`() {
+    fun `wellknown response should allow origin`() {
         withMockOAuth2Server {
-            client.get(this.wellKnownUrl("issuer")).asClue {
-                it.code shouldBe 200
-                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
-            }
+            client
+                .withHeaders(mapOf(HttpHeaderNames.ORIGIN.toString() to "http://somehost/"))
+                .get(this.wellKnownUrl("issuer")).asClue {
+                    it.code shouldBe 200
+                    it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "http://somehost/"
+                }
         }
     }
 
     @Test
-    fun `jwks response should allow all origins`() {
+    fun `jwks response should allow origin`() {
         withMockOAuth2Server {
-            client.get(this.jwksUrl("issuer")).asClue {
-                it.code shouldBe 200
-                it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
-            }
+            client
+                .withHeaders(mapOf(HttpHeaderNames.ORIGIN.toString() to "http://somehost/"))
+                .get(this.jwksUrl("issuer")).asClue {
+                    it.code shouldBe 200
+                    it.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "http://somehost/"
+                }
         }
     }
 
     @Test
-    fun `token response should allow all origins`() {
+    fun `token response should allow origin`() {
         withMockOAuth2Server {
             val expectedSubject = "expectedSub"
             val issuerId = "idprovider"
             this.enqueueCallback(DefaultOAuth2TokenCallback(issuerId = issuerId, subject = expectedSubject))
 
-            val response = client.tokenRequest(
-                this.tokenEndpointUrl(issuerId),
-                mapOf(
-                    "grant_type" to GrantType.REFRESH_TOKEN.value,
-                    "refresh_token" to "canbewhatever",
-                    "client_id" to "id",
-                    "client_secret" to "secret"
+            val response = client
+                .withHeaders(mapOf(HttpHeaderNames.ORIGIN.toString() to "http://somehost/"))
+                .tokenRequest(
+                    this.tokenEndpointUrl(issuerId),
+                    mapOf(
+                        "grant_type" to GrantType.REFRESH_TOKEN.value,
+                        "refresh_token" to "canbewhatever",
+                        "client_id" to "id",
+                        "client_secret" to "secret"
+                    )
                 )
-            )
 
             response.code shouldBe 200
-            response.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "*"
+            response.headers[HttpHeaderNames.ACCESS_CONTROL_ALLOW_ORIGIN.toString()] shouldBe "http://somehost/"
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Http.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Http.kt
@@ -35,6 +35,21 @@ fun client(followRedirects: Boolean = false): OkHttpClient =
         .followRedirects(followRedirects)
         .build()
 
+fun OkHttpClient.withHeaders(headers: Map<String, String>): OkHttpClient =
+    newBuilder().apply {
+        addInterceptor { chain ->
+            chain.request().newBuilder()
+                .headers(
+                    headers
+                        .flatMap { listOf(it.key, it.value) }
+                        .toTypedArray()
+                        .let { Headers.headersOf(*it) }
+                )
+                .build()
+                .let(chain::proceed)
+        }
+    }.build()
+
 fun OkHttpClient.withTrustStore(keyStore: KeyStore, followRedirects: Boolean = false): OkHttpClient =
     newBuilder().apply {
         followRedirects(followRedirects)


### PR DESCRIPTION
I discovered that the keycloak-js oidc client library wants to do token requests with the `withCredentials` flag. See https://github.com/keycloak/keycloak/blob/main/adapters/oidc/js/src/keycloak.js#L740 and https://github.com/keycloak/keycloak/blob/main/adapters/oidc/js/src/keycloak.js#L616 . Unfortunately this does not works with the current CORS implementation. Currently we return wildcard/`*` as allowed origin, but wildcard origin is not allowed when the credentials flag is set. See https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS#requests_with_credentials section `Credentialed requests and wildcards` which states:
```
If a request includes a credential (most commonly a Cookie header) and the response includes an Access-Control-Allow-Origin: * header (that is, with the wildcard), the browser will block access to the response, and report a CORS error in the devtools console.
```
The specifications also state that wildcards are not allowed for headers and methods, but at least Chrome does not block those.

As a consequence we need to set a concrete origin in the CORS headers since credentials are not allowed with wildcard origin. I've change the response headers to return CORS headers only when there is an origin in the request.

Please let me know what you think about this change.