### PR TITLE
Fix issue with host header and port handling

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -123,7 +123,13 @@ data class OAuth2HttpRequest(
                 .scheme(proto)
                 .host(hostFromHostHeader)
                 .apply {
-                    port?.toInt()?.let { port(it) } ?: port(portFromHostHeader)
+                    port?.toInt()?.let {
+                        port(it)
+                    } ?: run {
+                        if (portFromHostHeader != -1) {
+                            port(portFromHostHeader)
+                        }
+                    }
                 }
                 .encodedPath(originalUrl.encodedPath)
                 .query(originalUrl.query).build()

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -56,6 +56,19 @@ internal class OAuth2HttpRequestTest {
             originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req4.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io:666/mypath?query=1"
+
+        // Host header has only host and no x-forwarded-port
+        val req5 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host",
+                "fakedings.nais.io",
+                "x-forwarded-proto",
+                "https"
+            ),
+            method = "GET",
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req5.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io/mypath?query=1"
     }
 
     @Test


### PR DESCRIPTION
If there is no port on the Host header then it comes back -1 from the parsed URI, avoid passing that to the URL builder. The test added here fails without this code change so shows the issue.