### PR TITLE
Add arm64 architecture

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -61,6 +61,5 @@ jobs:
           IMAGE=${IMAGE_NAME}:${NEW_VERSION}
           echo "Releasing new version ${NEW_VERSION} of $IMAGE"
           ./gradlew -Pversion=${NEW_VERSION} publish publishToSonatype closeAndReleaseStagingRepository -Dorg.gradle.internal.publish.checksums.insecure=true --info
-          ./gradlew jibDockerBuild --image="${IMAGE}"
-          docker push "${IMAGE}"
+          ./gradlew jib --image="${IMAGE}"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -173,7 +173,17 @@ tasks.javadoc {
 
 jib {
     from {
-        image = "gcr.io/distroless/java:11"
+        platforms {
+            platform {
+                architecture = "amd64"
+                os = "linux"
+            }
+            platform {
+                architecture = "arm64"
+                os = "linux"
+            }
+        }
+        image = "gcr.io/distroless/java11-debian11"
     }
     container {
         ports = listOf("8080")


### PR DESCRIPTION
Add Multi-Arch Image support

I have tested locally on my m1 mac with
```
platforms {
            platform {
                architecture = "arm64"
                os = "linux"
            }
        }
image = "gcr.io/distroless/java11-debian11"
```