### PR TITLE
feat: support refreshtoken (as JWT) from keycloak

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeGrantHandler.kt
@@ -76,7 +76,7 @@ internal class AuthorizationCodeHandler(
         val loginTokenCallbackOrDefault = getLoginTokenCallbackOrDefault(code, oAuth2TokenCallback)
         val idToken: SignedJWT = tokenProvider.idToken(tokenRequest, issuerUrl, loginTokenCallbackOrDefault, nonce)
         val accessToken: SignedJWT = tokenProvider.accessToken(tokenRequest, issuerUrl, loginTokenCallbackOrDefault, nonce)
-        val refreshToken: RefreshToken = refreshTokenManager.refreshToken(loginTokenCallbackOrDefault)
+        val refreshToken: RefreshToken = refreshTokenManager.refreshToken(loginTokenCallbackOrDefault, nonce)
 
         return OAuth2TokenResponse(
             tokenType = "Bearer",

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
@@ -1,6 +1,7 @@
 package no.nav.security.mock.oauth2.grant
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.nimbusds.jwt.PlainJWT
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.ResponseMode
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
@@ -96,6 +97,16 @@ internal class AuthorizationCodeHandlerTest {
 
         handler.tokenResponse(tokenRequest(code = code), "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).asClue {
             SignedJWT.parse(it.idToken).claims.count() shouldBe 10
+        }
+    }
+
+    @Test
+    fun `auth request with nonce should result in a token response with refresh token as a JWT containing the nonce`() {
+        val code: String = handler.retrieveAuthorizationCode(Login("foo"))
+
+        handler.tokenResponse(tokenRequest(code = code), "http://myissuer".toHttpUrl(), DefaultOAuth2TokenCallback()).asClue {
+            val claims = PlainJWT.parse(it.refreshToken).jwtClaimsSet.claims
+            claims["nonce"] shouldBe "5678"
         }
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenManagerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenManagerTest.kt
@@ -1,0 +1,35 @@
+package no.nav.security.mock.oauth2.grant
+
+import com.nimbusds.jwt.PlainJWT
+import io.kotest.assertions.asClue
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
+import org.junit.jupiter.api.Test
+
+internal class RefreshTokenManagerTest {
+
+    @Test
+    fun `refresh token should be a jwt with nonce included if nonce is not null (for keycloak compatibility)`() {
+        val mgr = RefreshTokenManager()
+        val tokenCallback = DefaultOAuth2TokenCallback()
+
+        mgr.refreshToken(tokenCallback, "nonce123").asClue {
+            val claims = PlainJWT.parse(it).jwtClaimsSet.claims
+
+            claims["nonce"] shouldBe "nonce123"
+            claims["jti"] shouldNotBe null
+        }
+    }
+
+    @Test
+    fun `tokencallback should be available in cache for specific refresh token`() {
+        val mgr = RefreshTokenManager()
+        val tokenCallback = DefaultOAuth2TokenCallback()
+
+        val refreshToken = mgr.refreshToken(tokenCallback, null)
+        mgr[refreshToken] shouldBe tokenCallback
+        val refreshToken2 = mgr.refreshToken(tokenCallback, "nonce123")
+        mgr[refreshToken2] shouldBe tokenCallback
+    }
+}


### PR DESCRIPTION
Fixes #210 
* Ensures minimal compatibility with keycloak js client which expects the refresh token to be parseable JWT.
* Creates the refresh token as a Plain JWT (i.e. unsigned) containing `nonce` and `jti` if `nonce` is present in auth request