### PR TITLE
fix: dokka and add link in readme

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -25,13 +25,12 @@ jobs:
         run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Build Dokka
-        run: ./gradlew dokkaGfm -Pversion=${{ env.VERSION }}
+        run: ./gradlew dokkaHtm -Pversion=${{ env.VERSION }}
 
       - name: Publish documentation
         uses: JamesIves/github-pages-deploy-action@v4.3.3
         with:
-          branch: master
-          folder: build/dokka/gfm
+          branch: gh-pages
+          folder: build/dokka/html
           target-folder: docs
-          force: false
           commit-message: "doc: Add documentation for latest release: ${{ env.VERSION }}"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ The motivation behind this library is to provide a setup such that application d
 * **Standalone support** - i.e. run as application in IDE, run inside your app, or as a Docker image (provided)
 * **OAuth2 Client Debugger** - e.g. support for triggering OIDC Auth Code Flow and receiving callback in debugger app, view token response from server (intended for standalone support)
 
+## API Documentation
 
+[mock-oauth2-server](https://navikt.github.io/mock-oauth2-server/)
 
 ## 📦 Install
 


### PR DESCRIPTION
Had 2 config fails. But this is the winner, I´ve manually uploaded the doc to branch `gh-pages` in same repo.

Now for each release the doc will be updated in the Github pages.

See https://navikt.github.io/mock-oauth2-server for a preview.