### PR TITLE
Updates JWTAuthentication and JWTAuthenticationClaimsSet

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,7 +37,6 @@ plugins {
 }
 
 application {
-    applicationDefaultJvmArgs = mutableListOf("--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED")
     mainClassName = mainClassKt
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 val assertjVersion = "3.23.1"
 val kotlinLoggingVersion = "2.1.23"
 val logbackVersion = "1.2.11"
-val nimbusSdkVersion = "9.41.1"
+val nimbusSdkVersion = "9.43"
 val mockWebServerVersion = "4.10.0"
 val jacksonVersion = "2.13.3"
 val nettyVersion = "4.1.80.Final"
@@ -37,6 +37,7 @@ plugins {
 }
 
 application {
+    applicationDefaultJvmArgs = mutableListOf("--add-opens", "java.base/jdk.internal.loader=ALL-UNNAMED")
     mainClassName = mainClassKt
 }
 
@@ -273,6 +274,6 @@ tasks {
     }
 
     withType<Wrapper> {
-        gradleVersion = "7.4.2"
+        gradleVersion = "7.5.1"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,4 @@
 kotlin.code.style=official
 group=no.nav.security
+# workaround for kotest: see https://github.com/kotest/kotest/issues/3035
+org.gradle.jvmargs=--add-opens=java.base/java.util=ALL-UNNAMED

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
@@ -121,38 +121,6 @@ class TokenExchangeGrantIntegrationTest {
         }
     }
 
-    @AnnotationSpec.Ignore
-    fun `token request with client_assertion containing unequal iss and sub should fail`() {
-        withMockOAuth2Server {
-            val tokenEndpointUrl = this.tokenEndpointUrl("tokenx")
-
-            val clientAssertion = JWTClaimsSet.Builder()
-                .issuer("someissuer")
-                .subject("anothersubject")
-                .audience(tokenEndpointUrl.toString())
-                .issueTime(Date.from(Instant.now()))
-                .expirationTime(Date.from(Instant.now().plusSeconds(120)))
-                .notBeforeTime(Date.from(Instant.now()))
-                .jwtID(UUID.randomUUID().toString())
-                .build()
-                .sign(generateRsaKey())
-                .serialize()
-
-            val response: Response = client.tokenRequest(
-                url = tokenEndpointUrl,
-                parameters = mapOf(
-                    "grant_type" to TOKEN_EXCHANGE.value,
-                    "client_assertion_type" to ClientAssertionType.JWT_BEARER,
-                    "client_assertion" to clientAssertion,
-                    "subject_token_type" to SubjectTokenType.TOKEN_TYPE_JWT,
-                    "subject_token" to "na",
-                    "audience" to "na"
-                )
-            )
-            response.code shouldBe 400
-        }
-    }
-
     @Test
     fun `token request with client_assertion containing invalid aud should fail`() {
         withMockOAuth2Server {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
@@ -1,6 +1,7 @@
 package no.nav.security.mock.oauth2.e2e
 
 import com.nimbusds.jwt.JWTClaimsSet
+import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -120,7 +121,7 @@ class TokenExchangeGrantIntegrationTest {
         }
     }
 
-    @Test
+    @AnnotationSpec.Ignore
     fun `token request with client_assertion containing unequal iss and sub should fail`() {
         withMockOAuth2Server {
             val tokenEndpointUrl = this.tokenEndpointUrl("tokenx")


### PR DESCRIPTION
classes are updated to support iss != sub (iss #393).
read more her:
https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/src/49393129902c455bd58ae73355d2598d919c1f2f/CHANGELOG.txt#lines-2071

Gradle wrapper update introduced a bug:
added workaround for kotest in gradle.properties