### PR TITLE
Make sure the urls are resolved with the correct host

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -139,7 +139,17 @@ data class OAuth2HttpRequest(
                 .encodedPath(originalUrl.encodedPath)
                 .query(originalUrl.query).build()
         } else {
-            originalUrl
+            hostheader?.let {
+                val hostUri = URI(originalUrl.scheme, hostheader, null, null, null).parseServerAuthority()
+                HttpUrl.Builder()
+                    .scheme(hostUri.scheme)
+                    .host(hostUri.host)
+                    .port(hostUri.port)
+                    .encodedPath(originalUrl.encodedPath)
+                    .query(originalUrl.query)
+                    .build().also { println(it) }
+            } ?: originalUrl
+
         }
     }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -147,7 +147,7 @@ data class OAuth2HttpRequest(
                     .port(hostUri.port)
                     .encodedPath(originalUrl.encodedPath)
                     .query(originalUrl.query)
-                    .build().also { println(it) }
+                    .build()
             } ?: originalUrl
 
         }


### PR DESCRIPTION
In some situations, the host were resolved to container ids when running through docker and docker-compose. By explicitly building up the url using the hostname, it will work both when docker does internal networking as well as using localhost.