### PR TITLE
fix(jwt): provide algorithm when verifying signature and issuer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ Please fork the repo and start a new branch to work on.
 
 ## Building locally
 This project is using [Gradle](https://gradle.org/) for its build tool.
- A Gradle Wrapper is included in the code though so you do not have to manage your own installation.
+ A Gradle Wrapper is included in the code though, so you do not have to manage your own installation.
 
-To run a build simply exucute the following:
+To run a build simply execute the following:
 
 ```shell script
 ./gradlew build
@@ -23,7 +23,7 @@ If you are adding a new feature or bug fix please ensure there is proper test co
 If you have a branch on your fork that is ready to be merged, please create a new pull request. The maintainers will review to make sure the above guidelines have been followed and if the changes are helpful to all library users, they will be merged.
 
 ## Releasing
-The release process has been automated in Github Actions. Every merge into master is automatically added to the 
+The release process has been automated in GitHub Actions. Every merge into master is automatically added to the 
 [draft release notes](https://github.com/navikt/mock-oauth2-server/releases) of the next version. Once the next 
 version is ready to be released, simply publish the release with the version name as the title and tag and this 
 will trigger to publishing process.

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ Have a look at some examples in both Java and Kotlin in the src/test directory:
 
 ##### Server URLs
 
-You can retrieve URLs from the server with the correct port and issuerId etc by invoking one of the ` fun *Url(issuerId: String): HttpUrl` functions/methods: 
+You can retrieve URLs from the server with the correct port and issuerId etc. by invoking one of the ` fun *Url(issuerId: String): HttpUrl` functions/methods: 
 
 ```kotlin
 val server = MockOAuth2Server()
@@ -293,7 +293,7 @@ add this to your config with preferred `JWS algorithm`:
 
 *From the JSON example above:* 
 
-A token request to `http://localhost:8080/issuer1/token` with parameter `scope` equal to `scope1` will match the first tokencallback:
+A token request to `http://localhost:8080/issuer1/token` with parameter `scope` equal to `scope1` will match the first `tokenCallback`:
 
 ```json
 {
@@ -448,7 +448,7 @@ This project is currently maintained by the organisation [@navikt](https://githu
 
 If you need to raise an issue or question about this library, please create an issue here and tag it with the appropriate label.
 
-For contact requests within the [@navikt](https://github.com/navikt) org, you can use the slack channel #pig_sikkerhet
+For contact requests within the [@navikt](https://github.com/navikt) org, you can use the Slack channel #pig_sikkerhet
 
 If you need to contact anyone directly, please see contributors.
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -45,6 +45,7 @@ open class MockOAuth2Server(
     vararg additionalRoutes: Route
 ) {
     constructor(vararg additionalRoutes: Route) : this(config = OAuth2Config(), additionalRoutes = additionalRoutes)
+    constructor(config: OAuth2Config) : this(config = config, additionalRoutes = emptyArray())
 
     private val httpServer = config.httpServer
     private val defaultRequestHandler: OAuth2HttpRequestHandler = OAuth2HttpRequestHandler(config)
@@ -304,9 +305,10 @@ internal fun Map<String, Any>.toJwtClaimsSet(): JWTClaimsSet =
         }.build()
 
 fun <R> withMockOAuth2Server(
+    config: OAuth2Config = OAuth2Config(),
     test: MockOAuth2Server.() -> R
 ): R {
-    val server = MockOAuth2Server()
+    val server = MockOAuth2Server(config)
     server.start()
     try {
         return server.test()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -149,7 +149,6 @@ data class OAuth2HttpRequest(
                     .query(originalUrl.query)
                     .build()
             } ?: originalUrl
-
         }
     }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/introspect/Introspect.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/introspect/Introspect.kt
@@ -54,8 +54,9 @@ private fun OAuth2HttpRequest.verifyToken(tokenProvider: OAuth2TokenProvider): J
     val tokenString = this.formParameters.get("token")
     val issuer = url.toIssuerUrl()
     val jwkSet = tokenProvider.publicJwkSet(issuer.issuerId())
+    val algorithm = tokenProvider.getAlgorithm()
     return try {
-        SignedJWT.parse(tokenString).verifySignatureAndIssuer(Issuer(issuer.toString()), jwkSet)
+        SignedJWT.parse(tokenString).verifySignatureAndIssuer(Issuer(issuer.toString()), jwkSet, algorithm)
     } catch (e: Exception) {
         log.debug("token_introspection: failed signature validation")
         return null

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyGenerator.kt
@@ -86,7 +86,9 @@ data class KeyGenerator(
                             }
                         }
                     ).keyGenerator
-                } else null
+                } else {
+                    null
+                }
             }.singleOrNull() ?: throw OAuth2Exception("Unsupported algorithm: $algorithm")
         }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -27,6 +27,10 @@ class OAuth2TokenProvider @JvmOverloads constructor(
         return JWKSet(keyProvider.signingKey(issuerId)).toPublicJWKSet()
     }
 
+    fun getAlgorithm(): JWSAlgorithm {
+        return keyProvider.algorithm()
+    }
+
     fun idToken(
         tokenRequest: TokenRequest,
         issuerUrl: HttpUrl,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
@@ -30,8 +30,9 @@ private fun OAuth2HttpRequest.verifyBearerToken(tokenProvider: OAuth2TokenProvid
     val tokenString = this.headers.bearerToken()
     val issuer = url.toIssuerUrl()
     val jwkSet = tokenProvider.publicJwkSet(issuer.issuerId())
+    val algorithm = tokenProvider.getAlgorithm()
     return try {
-        SignedJWT.parse(tokenString).verifySignatureAndIssuer(Issuer(issuer.toString()), jwkSet)
+        SignedJWT.parse(tokenString).verifySignatureAndIssuer(Issuer(issuer.toString()), jwkSet, algorithm)
     } catch (e: Exception) {
         throw invalidToken(e.message ?: "could not verify bearer token")
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
@@ -1,7 +1,6 @@
 package no.nav.security.mock.oauth2.e2e
 
 import com.nimbusds.jwt.JWTClaimsSet
-import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/UserInfoIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/UserInfoIntegrationTest.kt
@@ -1,12 +1,18 @@
 package no.nav.security.mock.oauth2.e2e
 
+import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jwt.SignedJWT
 import io.kotest.assertions.asClue
 import io.kotest.matchers.maps.shouldContainAll
+import io.kotest.matchers.shouldBe
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.mock.oauth2.OAuth2Config
 import no.nav.security.mock.oauth2.testutils.claims
 import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
 import no.nav.security.mock.oauth2.testutils.parse
+import no.nav.security.mock.oauth2.token.KeyProvider
+import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import no.nav.security.mock.oauth2.withMockOAuth2Server
 import okhttp3.Headers
 import org.junit.jupiter.api.Test
@@ -14,6 +20,9 @@ import org.junit.jupiter.api.Test
 class UserInfoIntegrationTest {
 
     private val client = client()
+    private val rs384Config = OAuth2Config(
+        tokenProvider = OAuth2TokenProvider(keyProvider = KeyProvider(initialKeys = emptyList(), algorithm = JWSAlgorithm.RS384.name))
+    )
 
     @Test
     fun `userinfo should return claims from token when valid bearer token is present`() {
@@ -29,6 +38,41 @@ class UserInfoIntegrationTest {
                     "iss" to token.claims["iss"],
                     "extra" to token.claims["extra"]
                 )
+            }
+        }
+    }
+
+    @Test
+    fun `userinfo should return claims from token signed with non-default algorithm when valid bearer token is present`() {
+        withMockOAuth2Server(config = rs384Config) {
+            val issuerId = "default"
+            val token = this.issueToken(issuerId = issuerId, subject = "foo", claims = mapOf("extra" to "bar"))
+            token.header.algorithm.shouldBe(JWSAlgorithm.RS384)
+            client.get(
+                url = this.userInfoUrl(issuerId),
+                headers = token.asBearerTokenHeader()
+            ).asClue {
+                it.parse<Map<String, Any>>() shouldContainAll mapOf(
+                    "sub" to token.claims["sub"],
+                    "iss" to token.claims["iss"],
+                    "extra" to token.claims["extra"]
+                )
+            }
+        }
+    }
+
+    @Test
+    fun `userinfo should return error from token signed with non-default algorithm does not match server config`() {
+        val issuerId = "default"
+        val rs384Server = MockOAuth2Server(config = rs384Config)
+        val token = rs384Server.issueToken(issuerId = issuerId, subject = "foo", claims = mapOf("extra" to "bar"))
+        withMockOAuth2Server {
+            client.get(
+                url = this.userInfoUrl(issuerId),
+                headers = token.asBearerTokenHeader()
+            ).asClue {
+                it.code shouldBe 401
+                it.message shouldBe "Client Error"
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
@@ -34,7 +34,6 @@ internal class IntrospectTest {
             "sub" to "foo"
         )
         val token = tokenProvider.jwt(claims)
-        println("token: " + token.jwtClaimsSet.toJSONObject())
         val request = request("$issuerUrl$INTROSPECT", token.serialize())
 
         routes { introspect(tokenProvider) }.invoke(request).asClue {
@@ -55,7 +54,6 @@ internal class IntrospectTest {
             "sub" to "foo"
         )
         val token = rs384TokenProvider.jwt(claims)
-        println("token: " + token.jwtClaimsSet.toJSONObject())
         val request = request("$issuerUrl$INTROSPECT", token.serialize())
 
         routes { introspect(rs384TokenProvider) }.invoke(request).asClue {
@@ -100,7 +98,6 @@ internal class IntrospectTest {
             "sub" to "foo"
         )
         val token = rs384TokenProvider.jwt(claims)
-        println("token: " + token.jwtClaimsSet.toJSONObject())
         val request = request("$issuerUrl$INTROSPECT", token.serialize())
 
         routes {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
@@ -2,6 +2,7 @@ package no.nav.security.mock.oauth2.introspect
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.nimbusds.jose.JWSAlgorithm
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.maps.shouldContain
@@ -13,12 +14,14 @@ import no.nav.security.mock.oauth2.extensions.OAuth2Endpoints.INTROSPECT
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.OAuth2HttpResponse
 import no.nav.security.mock.oauth2.http.routes
+import no.nav.security.mock.oauth2.token.KeyProvider
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
 
 internal class IntrospectTest {
+    private val rs384TokenProvider = OAuth2TokenProvider(keyProvider = KeyProvider(initialKeys = emptyList(), algorithm = JWSAlgorithm.RS384.name))
 
     @Test
     fun `introspect should return active and claims from bearer token`() {
@@ -35,6 +38,27 @@ internal class IntrospectTest {
         val request = request("$issuerUrl$INTROSPECT", token.serialize())
 
         routes { introspect(tokenProvider) }.invoke(request).asClue {
+            it.status shouldBe 200
+            val response = it.parse<Map<String, Any>>()
+            response shouldContainAll claims
+            response shouldContain ("active" to true)
+        }
+    }
+
+    @Test
+    fun `introspect should return active and claims for non-default algorithm from bearer token`() {
+        val issuerUrl = "http://localhost/default"
+        val claims = mapOf(
+            "iss" to issuerUrl,
+            "client_id" to "yolo",
+            "token_type" to "token",
+            "sub" to "foo"
+        )
+        val token = rs384TokenProvider.jwt(claims)
+        println("token: " + token.jwtClaimsSet.toJSONObject())
+        val request = request("$issuerUrl$INTROSPECT", token.serialize())
+
+        routes { introspect(rs384TokenProvider) }.invoke(request).asClue {
             it.status shouldBe 200
             val response = it.parse<Map<String, Any>>()
             response shouldContainAll claims
@@ -61,6 +85,27 @@ internal class IntrospectTest {
         routes {
             introspect(OAuth2TokenProvider())
         }.invoke(request(url, "invalid")).asClue {
+            it.status shouldBe 200
+            it.parse<Map<String, Any>>() shouldContainExactly mapOf("active" to false)
+        }
+    }
+
+    @Test
+    fun `introspect should return active false when token was signed with a different algorithm than token provider`() {
+        val issuerUrl = "http://localhost/default"
+        val claims = mapOf(
+            "iss" to issuerUrl,
+            "client_id" to "yolo",
+            "token_type" to "token",
+            "sub" to "foo"
+        )
+        val token = rs384TokenProvider.jwt(claims)
+        println("token: " + token.jwtClaimsSet.toJSONObject())
+        val request = request("$issuerUrl$INTROSPECT", token.serialize())
+
+        routes {
+            introspect(OAuth2TokenProvider())
+        }.invoke(request).asClue {
             it.status shouldBe 200
             it.parse<Map<String, Any>>() shouldContainExactly mapOf("active" to false)
         }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfoTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfoTest.kt
@@ -2,6 +2,7 @@ package no.nav.security.mock.oauth2.userinfo
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fasterxml.jackson.module.kotlin.readValue
+import com.nimbusds.jose.JWSAlgorithm
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.maps.shouldContainAll
@@ -11,6 +12,7 @@ import no.nav.security.mock.oauth2.extensions.OAuth2Endpoints.USER_INFO
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.OAuth2HttpResponse
 import no.nav.security.mock.oauth2.http.routes
+import no.nav.security.mock.oauth2.token.KeyProvider
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -33,6 +35,29 @@ internal class UserInfoTest {
         routes { userInfo(tokenProvider) }.invoke(request).asClue {
             it.status shouldBe 200
             it.parse<Map<String, Any>>() shouldContainAll claims
+        }
+    }
+
+    @Test
+    fun `userinfo should throw OAuth2Exception when algorithm does not match`() {
+        val issuerUrl = "http://localhost/default"
+        val tokenProvider = OAuth2TokenProvider(keyProvider = KeyProvider(algorithm = JWSAlgorithm.RS384.name))
+        val claims = mapOf(
+            "iss" to issuerUrl,
+            "sub" to "foo",
+            "extra" to "bar"
+        )
+        val bearerToken = tokenProvider.jwt(claims)
+        val request = request("$issuerUrl$USER_INFO", bearerToken.serialize())
+
+        shouldThrow<OAuth2Exception> {
+            routes {
+                userInfo(tokenProvider)
+            }.invoke(request)
+        }.asClue {
+            it.errorObject?.code shouldBe "invalid_token"
+            it.errorObject?.description shouldBe "Signed JWT rejected: Another algorithm expected, or no matching key(s) found"
+            it.errorObject?.httpStatusCode shouldBe 401
         }
     }
 


### PR DESCRIPTION
I just discovered this project yesterday and setup/used it with success today. 
This is the perfect fit for one of our internal project, so a huge thanks 🙏🏻 

This MR fixes the errors returned by some endpoints when using a non-default  `algorithm`, for instance `RS384`:

```json
{
  "tokenProvider" : {
    "keyProvider" : {
      "algorithm" : "RS384"
    }
  }
}
```

Before this MR, if the token generated with algorithms was different than `RS256`, the following error was returned by the `/userinfo` and `/introspect` endpoints :

```json
{
  "error_description": "signed jwt rejected: another algorithm expected, or no matching key(s) found",
  "error": "invalid_token"
}
```

:hammer_and_wrench: with :heart: by [Siemens](https://opensource.siemens.com/)