### PR TITLE
fix(OAuth2HttpRequest): smoke out the bug

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -118,13 +118,13 @@ data class OAuth2HttpRequest(
         )
 
     internal fun proxyAwareUrl(): HttpUrl {
-        val hostheader = this.headers["host"]
+        val hostHeader = this.headers["host"]
         val proto = this.headers["x-forwarded-proto"]
         val port = this.headers["x-forwarded-port"]
         val wellKnownMetadataHost = StandaloneConfig.SERVER_HOSTNAME.fromEnv()
         return when {
-            hostheader != null && proto != null -> {
-                proxyAwareUrl(hostheader, proto, port)
+            hostHeader != null && proto != null -> {
+                proxyAwareUrl(hostHeader, proto, port)
             }
             wellKnownMetadataHost != null -> {
                 originalUrl.newBuilder()
@@ -132,13 +132,13 @@ data class OAuth2HttpRequest(
                     .port(StandaloneConfig.port()).build()
             }
             else -> {
-                proxyAwareUrl(hostheader)
+                proxyAwareUrl(hostHeader)
             }
         }
     }
 
-    private fun proxyAwareUrl(hostheader: String, proto: String, port: String?): HttpUrl {
-        val hostUri = URI(null, hostheader, null, null, null).parseServerAuthority()
+    private fun proxyAwareUrl(hostHeader: String, proto: String, port: String?): HttpUrl {
+        val hostUri = URI(null, hostHeader, null, null, null).parseServerAuthority()
         val hostFromHostHeader = hostUri.host
         val portFromHostHeader = hostUri.port
 
@@ -158,9 +158,9 @@ data class OAuth2HttpRequest(
             .query(originalUrl.query).build()
     }
 
-    private fun proxyAwareUrl(hostheader: String?): HttpUrl {
-        return hostheader?.let {
-            val hostUri = URI(originalUrl.scheme, hostheader, null, null, null).parseServerAuthority()
+    private fun proxyAwareUrl(hostHeader: String?): HttpUrl {
+        return hostHeader?.let {
+            val hostUri = URI(originalUrl.scheme, hostHeader, null, null, null).parseServerAuthority()
             originalUrl.newBuilder()
                 .host(hostUri.host)
                 .apply {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -1,5 +1,6 @@
 package no.nav.security.mock.oauth2.http
 
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.shouldBe
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -69,6 +70,26 @@ internal class OAuth2HttpRequestTest {
             originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
         )
         req5.proxyAwareUrl().toString() shouldBe "https://fakedings.nais.io/mypath?query=1"
+
+        val req6 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host",
+                "oauth2",
+            ),
+            method = "GET",
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req6.proxyAwareUrl().toString() shouldBe "http://oauth2/mypath?query=1"
+
+        val req7 = OAuth2HttpRequest(
+            headers = Headers.headersOf(
+                "host",
+                "oauth2:8080",
+            ),
+            method = "GET",
+            originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
+        )
+        req7.proxyAwareUrl().toString() shouldBe "http://oauth2:8080/mypath?query=1"
     }
 
     @Test
@@ -108,5 +129,41 @@ internal class OAuth2HttpRequestTest {
         req1.toWellKnown().endSessionEndpoint shouldBe "http://localhost:8080/mypath/endsession"
         req1.toWellKnown().tokenEndpoint shouldBe "http://localhost:8080/mypath/token"
         req1.toWellKnown().jwksUri shouldBe "http://localhost:8080/mypath/jwks"
+    }
+
+    @Test
+    fun `wellKnown localhost should with 'WELL_KNOWN_METADATA' return specified metadata`() {
+        withEnvironment(WELL_KNOWN_METADATA to "yolo") {
+            val req1 = OAuth2HttpRequest(
+                headers = Headers.headersOf(),
+                method = "GET",
+                originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl()
+            )
+
+            req1.toWellKnown().issuer shouldBe "http://yolo:8080/mypath"
+            req1.toWellKnown().userInfoEndpoint shouldBe "http://yolo:8080/mypath/userinfo"
+            req1.toWellKnown().authorizationEndpoint shouldBe "http://yolo:8080/mypath/authorize"
+            req1.toWellKnown().endSessionEndpoint shouldBe "http://yolo:8080/mypath/endsession"
+            req1.toWellKnown().tokenEndpoint shouldBe "http://yolo:8080/mypath/token"
+            req1.toWellKnown().jwksUri shouldBe "http://yolo:8080/mypath/jwks"
+        }
+    }
+
+    @Test
+    fun `wellKnown https should with 'WELL_KNOWN_METADATA' return specified metadata`() {
+        withEnvironment(WELL_KNOWN_METADATA to "yolo") {
+            val req1 = OAuth2HttpRequest(
+                headers = Headers.headersOf(),
+                method = "GET",
+                originalUrl = "https://some-host/mypath?query=1".toHttpUrl()
+            )
+
+            req1.toWellKnown().issuer shouldBe "https://yolo/mypath"
+            req1.toWellKnown().userInfoEndpoint shouldBe "https://yolo/mypath/userinfo"
+            req1.toWellKnown().authorizationEndpoint shouldBe "https://yolo/mypath/authorize"
+            req1.toWellKnown().endSessionEndpoint shouldBe "https://yolo/mypath/endsession"
+            req1.toWellKnown().tokenEndpoint shouldBe "https://yolo/mypath/token"
+            req1.toWellKnown().jwksUri shouldBe "https://yolo/mypath/jwks"
+        }
     }
 }


### PR DESCRIPTION
fails with -1. Should ignore and return requested host.

use `SERVER_HOSTNAME`