### PR TITLE
fix(logging): bump logback/slf4j to enable logging in docker

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -3,7 +3,7 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 
 val assertjVersion = "3.23.1"
 val kotlinLoggingVersion = "3.0.4"
-val logbackVersion = "1.2.11"
+val logbackVersion = "1.4.5"
 val nimbusSdkVersion = "10.4"
 val mockWebServerVersion = "4.10.0"
 val jacksonVersion = "2.14.1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,13 @@
+version: "3.1"
+
+services:
+  mock-oauth2-server:
+    image: mock-oauth2-server:latest
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./src/test/resources/config.json:/app/config.json
+    environment:
+      LOG_LEVEL: "debug"
+      SERVER_PORT: 8080
+      JSON_CONFIG_PATH: /app/config.json

--- a/src/test/resources/META-INF/spring.factories
+++ b/src/test/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.logging.LoggingSystemFactory=\
+org.springframework.boot.logging.java.JavaLoggingSystem.Factory


### PR DESCRIPTION
* fixes #388 by upgrading slf4j to 2.x (indirectly via logback)
* spring boot tests were failing due to Spring 2.7.x requiring slf4j 1.7.x
* added spring.factories to prevent Spring from using its LoggingSystemLogback class causing a NoClassDefFoundError on class removed from slf4j 2.x
* add sample docker-compose.yaml to easily test standalone mode