### PR TITLE
Added "code_challenge_methods_supported" to well known response

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,11 @@ A request to `http://localhost:8080/default/.well-known/openid-configuration` wi
      "PS256",
      "PS384",
      "PS512"
-   ]
+   ],
+  "code_challenge_methods_supported":[
+      "plain", 
+      "S256" 
+  ]
 }
 ```
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -42,6 +42,8 @@ data class WellKnown(
     val subjectTypesSupported: List<String> = listOf("public"),
     @JsonProperty("id_token_signing_alg_values_supported")
     val idTokenSigningAlgValuesSupported: List<String> = (KeyGenerator.ecAlgorithmFamily + KeyGenerator.rsaAlgorithmFamily).map { it.name }.toList(),
+    @JsonProperty("code_challenge_methods_supported")
+    val codeChallengeMethodsSupported: List<String> = listOf("plain", "S256"),
 )
 
 @JsonInclude(JsonInclude.Include.NON_NULL)


### PR DESCRIPTION
Hi, I am currently trying to use the mock server with the Okta JavaScript SDK. The client currently throws an error because the property "code_challenge_methods_supported" is missing in the .well-known response. 
If I add the property, the mock server can be used to mock Okta requests, which is really cool for local development purposes.