### PR TITLE
feat: add id-token to password grant token response

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/PasswordGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/PasswordGrantHandler.kt
@@ -22,10 +22,12 @@ internal class PasswordGrantHandler(
         val scope: String? = tokenRequest.scope?.toString()
         val passwordGrantTokenCallback = PasswordGrantTokenCallback(oAuth2TokenCallback)
         val accessToken: SignedJWT = tokenProvider.accessToken(tokenRequest, issuerUrl, passwordGrantTokenCallback)
+        val idToken: SignedJWT = tokenProvider.idToken(tokenRequest, issuerUrl, passwordGrantTokenCallback, null)
 
         return OAuth2TokenResponse(
             tokenType = "Bearer",
             accessToken = accessToken.serialize(),
+            idToken = idToken.serialize(),
             expiresIn = accessToken.expiresIn(),
             scope = scope,
         )

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/PasswordGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/PasswordGrantIntegrationTest.kt
@@ -43,6 +43,10 @@ class PasswordGrantIntegrationTest {
             response.accessToken should verifyWith(issuerId, this)
             response.accessToken.subject shouldBe "foo"
             response.accessToken.audience shouldContainExactly listOf("scope1")
+            response.idToken.shouldNotBeNull()
+            response.idToken should verifyWith(issuerId, this)
+            response.idToken.subject shouldBe "foo"
+            response.idToken.audience shouldContainExactly listOf("client")
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Token.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Token.kt
@@ -77,8 +77,12 @@ infix fun ParsedTokenResponse.shouldBeValidFor(type: GrantType) {
                 idToken shouldNotBe null
                 refreshToken shouldNotBe null
             }
-            TOKEN_EXCHANGE, JWT_BEARER, CLIENT_CREDENTIALS, PASSWORD -> {
+            TOKEN_EXCHANGE, JWT_BEARER, CLIENT_CREDENTIALS -> {
                 idToken shouldBe null
+                refreshToken shouldBe null
+            }
+            PASSWORD -> {
+                idToken shouldNotBe null
                 refreshToken shouldBe null
             }
         }


### PR DESCRIPTION
IDP's like Keycloak include the id-token (among others) in the token response for the password flow. Unfortunately there are older applications out there relying on this :(. Would be cool to also have a similar behavior here in mock-oauth2-server.