### PR TITLE
feat(DefaultOAuth2TokenCallback): Allow overriding tid claim

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -60,13 +60,11 @@ open class DefaultOAuth2TokenCallback
         }
 
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
-            claims.toMutableMap().apply {
-                putAll(
-                    mapOf(
-                        "azp" to tokenRequest.clientIdAsString(),
-                        "tid" to issuerId,
-                    ),
-                )
+            mutableMapOf<String, Any>(
+                "tid" to issuerId,
+            ).apply {
+                putAll(claims)
+                put("azp", tokenRequest.clientIdAsString())
             }
 
         override fun tokenExpiry(): Long = expiry

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -149,6 +149,19 @@ internal class OAuth2TokenCallbackTest {
                 }
             }
         }
+
+        @Test
+        fun `Allow overriding tid`() {
+            val tokenRequest = clientCredentialsRequest()
+            DefaultOAuth2TokenCallback().asClue {
+                it.addClaims(tokenRequest) shouldContainAll mapOf("tid" to "default")
+            }
+
+            DefaultOAuth2TokenCallback(claims = mapOf("tid" to "test-tid")).asClue {
+                it.addClaims(tokenRequest) shouldContainAll mapOf("tid" to "test-tid")
+            }
+        }
+
     }
 
     private fun authCodeRequest(vararg formParams: Pair<String, String>) =


### PR DESCRIPTION
As it's not a standard claim, it should be possible to override it by the consumer of the library.

azp is defined in https://openid.net/specs/openid-connect-core-1_0.html as the "OAuth 2.0 Client ID of this party", so leaving that one as is.