### PR TITLE
Exclude logback.xml from jar

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -305,4 +305,9 @@ tasks {
     withType<Wrapper> {
         gradleVersion = "8.3"
     }
+
+    // Exclude logback.xml from the jar to not override projects logback config
+    withType<Jar> {
+        exclude("logback.xml")
+    }
 }


### PR DESCRIPTION
As discussed in #658 i would like to exclude the logback.xml from the jar, to prevent overwriting the project specific logback config.