### PR TITLE
feat: support custom TimeProvider when validating tokens (introspect, userinfo)

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -3,9 +3,12 @@ package no.nav.security.mock.oauth2.token
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.JWKSelector
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.KeyType
 import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.source.JWKSource
+import com.nimbusds.jose.proc.SecurityContext
 import no.nav.security.mock.oauth2.OAuth2Exception
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.LinkedBlockingDeque
@@ -15,7 +18,7 @@ open class KeyProvider
     constructor(
         private val initialKeys: List<JWK> = keysFromFile(INITIAL_KEYS_FILE),
         private val algorithm: String = JWSAlgorithm.RS256.name,
-    ) {
+    ) : JWKSource<SecurityContext> {
         private val signingKeys: ConcurrentHashMap<String, JWK> = ConcurrentHashMap()
 
         private var generator: KeyGenerator = KeyGenerator(JWSAlgorithm.parse(algorithm))
@@ -35,9 +38,11 @@ open class KeyProvider
                     KeyType.RSA.value -> {
                         RSAKey.Builder(polledJwk.toRSAKey()).keyID(keyId).build()
                     }
+
                     KeyType.EC.value -> {
                         ECKey.Builder(polledJwk.toECKey()).keyID(keyId).build()
                     }
+
                     else -> {
                         throw OAuth2Exception("Unsupported key type: ${polledJwk.keyType.value}")
                     }
@@ -62,5 +67,12 @@ open class KeyProvider
                 }
                 return emptyList()
             }
+        }
+
+        override fun get(
+            jwkSelector: JWKSelector?,
+            context: SecurityContext?,
+        ): MutableList<JWK> {
+            return signingKeys.values.toMutableList()
         }
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/KeyProvider.kt
@@ -72,7 +72,6 @@ open class KeyProvider
         override fun get(
             jwkSelector: JWKSelector?,
             context: SecurityContext?,
-        ): MutableList<JWK> {
-            return signingKeys.values.toMutableList()
-        }
+        ): MutableList<JWK> = jwkSelector?.select(JWKSet(signingKeys.values.toList()).toPublicJWKSet()) ?: mutableListOf()
+
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -114,9 +114,7 @@ class OAuth2TokenProvider
         fun verify(
             issuerUrl: HttpUrl,
             token: String,
-        ): JWTClaimsSet {
-            return SignedJWT.parse(token).verify(issuerUrl)
-        }
+        ): JWTClaimsSet = SignedJWT.parse(token).verify(issuerUrl)
 
         private fun JWTClaimsSet.sign(
             issuerId: String,
@@ -203,9 +201,7 @@ class OAuth2TokenProvider
                             JWTClaimsSet.Builder().issuer(issuerUrl.toString()).build(),
                             HashSet(listOf("iat", "exp")),
                         ) {
-                            override fun currentTime(): Date {
-                                return Date.from(timeProvider())
-                            }
+                            override fun currentTime(): Date = Date.from(timeProvider().orNow())
                         }
                 }
             return jwtProcessor.process(this, null)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProvider.kt
@@ -7,8 +7,13 @@ import com.nimbusds.jose.crypto.ECDSASigner
 import com.nimbusds.jose.crypto.RSASSASigner
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.KeyType
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
+import com.nimbusds.jose.proc.JWSVerificationKeySelector
+import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.DefaultJWTClaimsVerifier
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
 import com.nimbusds.oauth2.sdk.TokenRequest
 import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.clientIdAsString
@@ -106,6 +111,13 @@ class OAuth2TokenProvider
                     builder.build()
                 }.sign(issuerId, JOSEObjectType.JWT.type)
 
+        fun verify(
+            issuerUrl: HttpUrl,
+            token: String,
+        ): JWTClaimsSet {
+            return SignedJWT.parse(token).verify(issuerUrl)
+        }
+
         private fun JWTClaimsSet.sign(
             issuerId: String,
             type: String,
@@ -124,6 +136,7 @@ class OAuth2TokenProvider
                         sign(RSASSASigner(key.toRSAKey().toPrivateKey()))
                     }
                 }
+
                 supported && keyType == KeyType.EC.value -> {
                     SignedJWT(
                         jwsHeader(key.keyID, type, algorithm),
@@ -132,6 +145,7 @@ class OAuth2TokenProvider
                         sign(ECDSASigner(key.toECKey().toECPrivateKey()))
                     }
                 }
+
                 else -> {
                     throw OAuth2Exception("Unsupported algorithm: ${algorithm.name}")
                 }
@@ -178,4 +192,22 @@ class OAuth2TokenProvider
         }
 
         private fun Instant?.orNow(): Instant = this ?: Instant.now()
+
+        private fun SignedJWT.verify(issuerUrl: HttpUrl): JWTClaimsSet {
+            val jwtProcessor =
+                DefaultJWTProcessor<SecurityContext?>().apply {
+                    jwsTypeVerifier = DefaultJOSEObjectTypeVerifier(JOSEObjectType("JWT"))
+                    jwsKeySelector = JWSVerificationKeySelector(keyProvider.algorithm(), keyProvider)
+                    jwtClaimsSetVerifier =
+                        object : DefaultJWTClaimsVerifier<SecurityContext?>(
+                            JWTClaimsSet.Builder().issuer(issuerUrl.toString()).build(),
+                            HashSet(listOf("iat", "exp")),
+                        ) {
+                            override fun currentTime(): Date {
+                                return Date.from(timeProvider())
+                            }
+                        }
+                }
+            return jwtProcessor.process(this, null)
+        }
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
@@ -22,13 +22,12 @@ internal fun Route.Builder.userInfo(tokenProvider: OAuth2TokenProvider) =
         json(claims)
     }
 
-private fun OAuth2HttpRequest.verifyBearerToken(tokenProvider: OAuth2TokenProvider): JWTClaimsSet {
-    return try {
+private fun OAuth2HttpRequest.verifyBearerToken(tokenProvider: OAuth2TokenProvider): JWTClaimsSet =
+    try {
         tokenProvider.verify(url.toIssuerUrl(), this.headers.bearerToken())
     } catch (e: Exception) {
         throw invalidToken(e.message ?: "could not verify bearer token")
     }
-}
 
 private fun Headers.bearerToken(): String =
     this["Authorization"]

--- a/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfo.kt
@@ -1,16 +1,12 @@
 package no.nav.security.mock.oauth2.userinfo
 
 import com.nimbusds.jwt.JWTClaimsSet
-import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.ErrorObject
 import com.nimbusds.oauth2.sdk.http.HTTPResponse
-import com.nimbusds.oauth2.sdk.id.Issuer
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.OAuth2Endpoints.USER_INFO
-import no.nav.security.mock.oauth2.extensions.issuerId
 import no.nav.security.mock.oauth2.extensions.toIssuerUrl
-import no.nav.security.mock.oauth2.extensions.verifySignatureAndIssuer
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.Route
 import no.nav.security.mock.oauth2.http.json
@@ -27,12 +23,8 @@ internal fun Route.Builder.userInfo(tokenProvider: OAuth2TokenProvider) =
     }
 
 private fun OAuth2HttpRequest.verifyBearerToken(tokenProvider: OAuth2TokenProvider): JWTClaimsSet {
-    val tokenString = this.headers.bearerToken()
-    val issuer = url.toIssuerUrl()
-    val jwkSet = tokenProvider.publicJwkSet(issuer.issuerId())
-    val algorithm = tokenProvider.getAlgorithm()
     return try {
-        SignedJWT.parse(tokenString).verifySignatureAndIssuer(Issuer(issuer.toString()), jwkSet, algorithm)
+        tokenProvider.verify(url.toIssuerUrl(), this.headers.bearerToken())
     } catch (e: Exception) {
         throw invalidToken(e.message ?: "could not verify bearer token")
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProviderRSATest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenProviderRSATest.kt
@@ -51,31 +51,33 @@ internal class OAuth2TokenProviderRSATest {
                 ),
             )
 
-        tokenProvider.exchangeAccessToken(
-            tokenRequest =
-                nimbusTokenRequest(
-                    "myclient",
-                    "grant_type" to GrantType.JWT_BEARER.value,
-                    "scope" to "scope1",
-                    "assertion" to initialToken.serialize(),
-                ),
-            issuerUrl = "http://default_if_not_overridden".toHttpUrl(),
-            claimsSet = initialToken.jwtClaimsSet,
-            oAuth2TokenCallback =
-                DefaultOAuth2TokenCallback(
-                    claims =
-                        mapOf(
-                            "extraclaim" to "extra",
-                            "iss" to "http://overrideissuer",
-                        ),
-                ),
-        ).jwtClaimsSet.asClue {
-            it.issuer shouldBe "http://overrideissuer"
-            it.subject shouldBe "initialsubject"
-            it.audience shouldBe listOf("scope1")
-            it.claims["initialclaim"] shouldBe "initialclaim"
-            it.claims["extraclaim"] shouldBe "extra"
-        }
+        tokenProvider
+            .exchangeAccessToken(
+                tokenRequest =
+                    nimbusTokenRequest(
+                        "myclient",
+                        "grant_type" to GrantType.JWT_BEARER.value,
+                        "scope" to "scope1",
+                        "assertion" to initialToken.serialize(),
+                    ),
+                issuerUrl = "http://default_if_not_overridden".toHttpUrl(),
+                claimsSet = initialToken.jwtClaimsSet,
+                oAuth2TokenCallback =
+                    DefaultOAuth2TokenCallback(
+                        claims =
+                            mapOf(
+                                "extraclaim" to "extra",
+                                "iss" to "http://overrideissuer",
+                            ),
+                    ),
+            ).jwtClaimsSet
+            .asClue {
+                it.issuer shouldBe "http://overrideissuer"
+                it.subject shouldBe "initialsubject"
+                it.audience shouldBe listOf("scope1")
+                it.claims["initialclaim"] shouldBe "initialclaim"
+                it.claims["extraclaim"] shouldBe "extra"
+            }
     }
 
     @Test
@@ -106,7 +108,7 @@ internal class OAuth2TokenProviderRSATest {
             it.jwtClaimsSet.issueTime shouldBe Date.from(tokenProvider.systemTime)
         }
 
-        val now = Instant.now()
+        val now = Instant.now().minus(1, ChronoUnit.SECONDS)
         OAuth2TokenProvider().clientCredentialsToken("http://localhost/default").asClue {
             it.jwtClaimsSet.issueTime shouldBeAfter now
         }


### PR DESCRIPTION
Currently we only verify tokens issued from the server in the UserInfo and Introspection endpoints (other endpoints simply use the token as is without verification). This should fix #700 by using new verify function from the `OAuth2TokenProvider` class. 

* add verify function to OAuth2TokenProvider and use the TimeProvider if set - i.e. via overriding Nimbus DefaultJWTClaimsVerifier's currentTime function
* refactor tests for simplicity