### PR TITLE
fix(logback): set logback severity back to INFO

### DIFF
--- a/src/main/resources/logback-standalone.xml
+++ b/src/main/resources/logback-standalone.xml
@@ -10,7 +10,7 @@
 
     <logger name="io.netty" level="info" />
 
-    <variable name="LOG_LEVEL" value="${LOG_LEVEL:-DEBUG}" />
+    <variable name="LOG_LEVEL" value="${LOG_LEVEL:-INFO}" />
     <root level="${LOG_LEVEL}">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
This matches what the documentation suggests. I guess this changed by accident in
https://github.com/navikt/mock-oauth2-server/pull/667