### PR TITLE
feat: prefer issuer as client assertion audience for private_key_jwt auth

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Exception.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Exception.kt
@@ -23,12 +23,12 @@ fun missingParameter(name: String): Nothing =
 
 fun invalidGrant(grantType: GrantType): Nothing =
     "grant_type $grantType not supported.".let {
-        throw OAuth2Exception(OAuth2Error.INVALID_GRANT, it)
+        throw OAuth2Exception(OAuth2Error.INVALID_GRANT.setDescription(it), it)
     }
 
 fun invalidRequest(message: String): Nothing =
     message.let {
-        throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, message)
+        throw OAuth2Exception(OAuth2Error.INVALID_REQUEST.setDescription(message), message)
     }
 
 fun notFound(message: String): Nothing = throw OAuth2Exception(ErrorObject("not_found", "Resource not found", HTTPResponse.SC_NOT_FOUND), message)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -35,7 +35,12 @@ data class OAuth2HttpRequest(
         val httpRequest: HTTPRequest = this.asNimbusHTTPRequest()
         var clientAuthentication = httpRequest.clientAuthentication()
         if (clientAuthentication.method == ClientAuthenticationMethod.PRIVATE_KEY_JWT) {
-            clientAuthentication = clientAuthentication.requirePrivateKeyJwt(this.url.toString(), 120)
+            clientAuthentication =
+                clientAuthentication.requirePrivateKeyJwt(
+                    requiredAudience = this.url.toIssuerUrl().toString(),
+                    maxLifetimeSeconds = 120,
+                    additionalAcceptedAudience = this.url.toTokenEndpointUrl().toString(),
+                )
         }
         val tokenExchangeGrant = TokenExchangeGrant.parse(formParameters.map)
 

--- a/src/test/kotlin/examples/kotlin/ktor/client/OAuth2Client.kt
+++ b/src/test/kotlin/examples/kotlin/ktor/client/OAuth2Client.kt
@@ -111,26 +111,26 @@ class Auth internal constructor(
         fun privateKeyJwt(
             keyPair: KeyPair,
             clientId: String,
-            tokenEndpoint: String,
+            audience: String,
             expiry: Duration = Duration.ofSeconds(120),
         ): Auth =
             Auth(
                 parameters =
                     mapOf(
                         "client_assertion_type" to CLIENT_ASSERTION_TYPE,
-                        "client_assertion" to keyPair.clientAssertion(clientId, tokenEndpoint, expiry),
+                        "client_assertion" to keyPair.clientAssertion(clientId, audience, expiry),
                     ),
             )
 
         private fun KeyPair.clientAssertion(
             clientId: String,
-            tokenEndpoint: String,
+            audience: String,
             expiry: Duration = Duration.ofSeconds(120),
         ): String {
             val now = Instant.now()
             return JWT
                 .create()
-                .withAudience(tokenEndpoint)
+                .withAudience(audience)
                 .withIssuer(clientId)
                 .withSubject(clientId)
                 .withJWTId(UUID.randomUUID().toString())

--- a/src/test/kotlin/examples/kotlin/ktor/client/OAuth2ClientTest.kt
+++ b/src/test/kotlin/examples/kotlin/ktor/client/OAuth2ClientTest.kt
@@ -55,6 +55,7 @@ internal class OAuth2ClientTest {
         runBlocking {
             val initialToken = server.issueToken(subject = "enduser")
             val tokenEndpointUrl = server.tokenEndpointUrl("default").toString()
+            val issuerUrl = server.issuerUrl("default").toString()
             val tokenResponse =
                 httpClient.onBehalfOfGrant(
                     url = tokenEndpointUrl,
@@ -62,7 +63,7 @@ internal class OAuth2ClientTest {
                         Auth.privateKeyJwt(
                             keyPair = KeyPairGenerator.getInstance("RSA").apply { initialize(2048) }.generateKeyPair(),
                             clientId = "client1",
-                            tokenEndpoint = tokenEndpointUrl,
+                            audience = issuerUrl,
                         ),
                     token = initialToken.serialize(),
                     scope = "targetScope",

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/TokenExchangeGrantIntegrationTest.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2.e2e
 
-import com.nimbusds.jwt.JWTClaimsSet
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -11,21 +10,16 @@ import no.nav.security.mock.oauth2.testutils.SubjectTokenType
 import no.nav.security.mock.oauth2.testutils.audience
 import no.nav.security.mock.oauth2.testutils.claims
 import no.nav.security.mock.oauth2.testutils.clientAssertion
-import no.nav.security.mock.oauth2.testutils.generateRsaKey
+import no.nav.security.mock.oauth2.testutils.issueSubjectToken
 import no.nav.security.mock.oauth2.testutils.shouldBeValidFor
-import no.nav.security.mock.oauth2.testutils.sign
 import no.nav.security.mock.oauth2.testutils.subject
 import no.nav.security.mock.oauth2.testutils.toTokenResponse
 import no.nav.security.mock.oauth2.testutils.tokenRequest
 import no.nav.security.mock.oauth2.testutils.verifyWith
-import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.withMockOAuth2Server
 import okhttp3.OkHttpClient
 import okhttp3.Response
 import org.junit.jupiter.api.Test
-import java.time.Instant
-import java.util.Date
-import java.util.UUID
 
 class TokenExchangeGrantIntegrationTest {
     private val client: OkHttpClient =
@@ -38,25 +32,12 @@ class TokenExchangeGrantIntegrationTest {
     fun `token request with token exchange grant should exchange subject_token with a new token containing many of the same claims`() {
         withMockOAuth2Server {
             val initialSubject = "yolo"
-            val initialToken =
-                this.issueToken(
-                    issuerId = "idprovider",
-                    clientId = "initialClient",
-                    tokenCallback =
-                        DefaultOAuth2TokenCallback(
-                            issuerId = "idprovider",
-                            subject = initialSubject,
-                            claims =
-                                mapOf(
-                                    "claim1" to "value1",
-                                    "claim2" to "value2",
-                                ),
-                        ),
-                )
+            val initialToken = issueSubjectToken(subject = initialSubject)
 
             val issuerId = "tokenx"
             val tokenEndpointUrl = this.tokenEndpointUrl(issuerId)
-            val clientAssertion = clientAssertion("tokenExchangeClient", tokenEndpointUrl.toUrl()).serialize()
+            val issuerUrl = this.issuerUrl(issuerId)
+            val clientAssertion = clientAssertion(clientId = "tokenExchangeClient", audience = issuerUrl.toString()).serialize()
             val targetAudienceForToken = "targetAudience"
 
             val response: ParsedTokenResponse =
@@ -92,21 +73,7 @@ class TokenExchangeGrantIntegrationTest {
     fun `token request with token exchange grant and client basic auth should exchange subject_token with a new token containing many of the same claims`() {
         withMockOAuth2Server {
             val initialSubject = "yolo"
-            val initialToken =
-                this.issueToken(
-                    issuerId = "idprovider",
-                    clientId = "initialClient",
-                    tokenCallback =
-                        DefaultOAuth2TokenCallback(
-                            issuerId = "idprovider",
-                            subject = initialSubject,
-                            claims =
-                                mapOf(
-                                    "claim1" to "value1",
-                                    "claim2" to "value2",
-                                ),
-                        ),
-                )
+            val initialToken = issueSubjectToken(subject = initialSubject)
 
             val issuerId = "tokenx"
             val tokenEndpointUrl = this.tokenEndpointUrl(issuerId)
@@ -120,6 +87,46 @@ class TokenExchangeGrantIntegrationTest {
                         parameters =
                             mapOf(
                                 "grant_type" to TOKEN_EXCHANGE.value,
+                                "subject_token_type" to SubjectTokenType.TOKEN_TYPE_JWT,
+                                "subject_token" to initialToken.serialize(),
+                                "audience" to targetAudienceForToken,
+                            ),
+                    ).toTokenResponse()
+
+            response shouldBeValidFor TOKEN_EXCHANGE
+            response.scope shouldBe null
+            response.tokenType shouldBe "Bearer"
+            response.issuedTokenType shouldBe "urn:ietf:params:oauth:token-type:access_token"
+
+            response.accessToken!! should verifyWith(issuerId, this)
+
+            response.accessToken.subject shouldBe initialSubject
+            response.accessToken.audience shouldContainExactly listOf(targetAudienceForToken)
+            response.accessToken.claims["claim1"] shouldBe "value1"
+            response.accessToken.claims["claim2"] shouldBe "value2"
+        }
+    }
+
+    @Test
+    fun `token request with client_assertion containing aud equal token endpoint should be allowed`() {
+        withMockOAuth2Server {
+            val initialSubject = "yolo"
+            val initialToken = issueSubjectToken(subject = initialSubject)
+
+            val issuerId = "tokenx"
+            val tokenEndpointUrl = this.tokenEndpointUrl(issuerId)
+            val clientAssertion = clientAssertion("clientid", tokenEndpointUrl.toString()).serialize()
+            val targetAudienceForToken = "targetAudience"
+
+            val response: ParsedTokenResponse =
+                client
+                    .tokenRequest(
+                        url = tokenEndpointUrl,
+                        parameters =
+                            mapOf(
+                                "grant_type" to TOKEN_EXCHANGE.value,
+                                "client_assertion_type" to ClientAssertionType.JWT_BEARER,
+                                "client_assertion" to clientAssertion,
                                 "subject_token_type" to SubjectTokenType.TOKEN_TYPE_JWT,
                                 "subject_token" to initialToken.serialize(),
                                 "audience" to targetAudienceForToken,
@@ -161,8 +168,10 @@ class TokenExchangeGrantIntegrationTest {
     @Test
     fun `token request with invalid client_assertion_type should fail`() {
         withMockOAuth2Server {
+            val initialToken = issueSubjectToken(subject = "some-subject")
             val tokenEndpointUrl = this.tokenEndpointUrl("tokenx")
-            val clientAssertion = clientAssertion("tokenExchangeClient", tokenEndpointUrl.toUrl()).serialize()
+            val issuerUrl = this.issuerUrl("tokenx")
+            val clientAssertion = clientAssertion(clientId = "tokenExchangeClient", audience = issuerUrl.toString()).serialize()
             val response: Response =
                 client.tokenRequest(
                     url = tokenEndpointUrl,
@@ -172,8 +181,8 @@ class TokenExchangeGrantIntegrationTest {
                             "client_assertion_type" to "some-invalid-type",
                             "client_assertion" to clientAssertion,
                             "subject_token_type" to SubjectTokenType.TOKEN_TYPE_JWT,
-                            "subject_token" to "na",
-                            "audience" to "na",
+                            "subject_token" to initialToken.serialize(),
+                            "audience" to "targetAudience",
                         ),
                 )
             response.code shouldBe 400
@@ -183,22 +192,10 @@ class TokenExchangeGrantIntegrationTest {
     @Test
     fun `token request with client_assertion containing invalid aud should fail`() {
         withMockOAuth2Server {
+            val initialToken = issueSubjectToken(subject = "some-subject")
             val tokenEndpointUrl = this.tokenEndpointUrl("tokenx")
 
-            val clientAssertion =
-                JWTClaimsSet
-                    .Builder()
-                    .issuer("clientid")
-                    .subject("clientid")
-                    .audience("invalid")
-                    .issueTime(Date.from(Instant.now()))
-                    .expirationTime(Date.from(Instant.now().plusSeconds(120)))
-                    .notBeforeTime(Date.from(Instant.now()))
-                    .jwtID(UUID.randomUUID().toString())
-                    .build()
-                    .sign(generateRsaKey())
-                    .serialize()
-
+            val clientAssertion = clientAssertion(clientId = "tokenExchangeClient", audience = "invalid").serialize()
             val response: Response =
                 client.tokenRequest(
                     url = tokenEndpointUrl,
@@ -208,8 +205,37 @@ class TokenExchangeGrantIntegrationTest {
                             "client_assertion_type" to ClientAssertionType.JWT_BEARER,
                             "client_assertion" to clientAssertion,
                             "subject_token_type" to SubjectTokenType.TOKEN_TYPE_JWT,
-                            "subject_token" to "na",
-                            "audience" to "na",
+                            "subject_token" to initialToken.serialize(),
+                            "audience" to "targetAudience",
+                        ),
+                )
+            response.code shouldBe 400
+        }
+    }
+
+    @Test
+    fun `token request with client_assertion containing multiple audiences should fail`() {
+        withMockOAuth2Server {
+            val initialToken = issueSubjectToken(subject = "some-subject")
+            val tokenEndpointUrl = this.tokenEndpointUrl("tokenx")
+            val issuerUrl = this.issuerUrl("tokenx")
+
+            val clientAssertion =
+                clientAssertion(
+                    clientId = "tokenExchangeClient",
+                    audiences = listOf(tokenEndpointUrl.toString(), issuerUrl.toString()),
+                ).serialize()
+            val response: Response =
+                client.tokenRequest(
+                    url = tokenEndpointUrl,
+                    parameters =
+                        mapOf(
+                            "grant_type" to TOKEN_EXCHANGE.value,
+                            "client_assertion_type" to ClientAssertionType.JWT_BEARER,
+                            "client_assertion" to clientAssertion,
+                            "subject_token_type" to SubjectTokenType.TOKEN_TYPE_JWT,
+                            "subject_token" to initialToken.serialize(),
+                            "audience" to "targetAudience",
                         ),
                 )
             response.code shouldBe 400


### PR DESCRIPTION
For backwards compatibility, the previous behavior where the `token_endpoint`
was required as audience value is still accepted.
    
Client assertions will however be validated more strictly than previously,
to be more in line with the current requirements of RFC 7523. Namely:
    
- the `iss` (issuer) and `sub` (subject) claim values must be equal to the client_id
- the `aud` (audience) claim must contain exactly one value