### PR TITLE
fix(introspect): exp, iat, nbf claims were always null

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/introspect/Introspect.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/introspect/Introspect.kt
@@ -1,5 +1,6 @@
 package no.nav.security.mock.oauth2.introspect
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.nimbusds.jwt.JWTClaimsSet
@@ -90,6 +91,7 @@ data class IntrospectResponse(
     @JsonProperty("sub")
     val sub: String? = null,
     @JsonProperty("aud")
+    @JsonFormat(with = [JsonFormat.Feature.WRITE_SINGLE_ELEM_ARRAYS_UNWRAPPED])
     val aud: List<String>? = null,
     @JsonProperty("iss")
     val iss: String? = null,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/introspect/Introspect.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/introspect/Introspect.kt
@@ -26,21 +26,20 @@ internal fun Route.Builder.introspect(tokenProvider: OAuth2TokenProvider) =
         }
 
         request.verifyToken(tokenProvider)?.let {
-            val claims = it.claims
             json(
                 IntrospectResponse(
                     true,
-                    claims["scope"].toString(),
-                    claims["client_id"].toString(),
-                    claims["username"].toString(),
-                    claims["token_type"].toString(),
-                    claims["exp"] as? Long,
-                    claims["iat"] as? Long,
-                    claims["nbf"] as? Long,
-                    claims["sub"].toString(),
-                    claims["aud"].toString(),
-                    claims["iss"].toString(),
-                    claims["jti"].toString(),
+                    it.getStringClaim("scope"),
+                    it.getStringClaim("client_id"),
+                    it.getStringClaim("username"),
+                    it.getStringClaim("token_type") ?: "Bearer",
+                    it.expirationTime?.time?.div(1000),
+                    it.issueTime?.time?.div(1000),
+                    it.notBeforeTime?.time?.div(1000),
+                    it.subject,
+                    it.audience,
+                    it.issuer,
+                    it.jwtid,
                 ),
             )
         } ?: json(IntrospectResponse(false))
@@ -91,7 +90,7 @@ data class IntrospectResponse(
     @JsonProperty("sub")
     val sub: String? = null,
     @JsonProperty("aud")
-    val aud: String? = null,
+    val aud: List<String>? = null,
     @JsonProperty("iss")
     val iss: String? = null,
     @JsonProperty("jti")

--- a/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
@@ -118,6 +118,52 @@ internal class IntrospectTest {
     }
 
     @Test
+    fun `introspect should return single audience as string`() {
+        val issuerUrl = "http://localhost/default"
+        val tokenProvider = OAuth2TokenProvider()
+        val claims =
+            mapOf(
+                "iss" to issuerUrl,
+                "client_id" to "yolo",
+                "token_type" to "token",
+                "sub" to "foo",
+                "aud" to "some-audience",
+            )
+        val token = tokenProvider.jwt(claims)
+        val request = request("$issuerUrl$INTROSPECT", token.serialize())
+
+        routes { introspect(tokenProvider) }.invoke(request).asClue {
+            it.status shouldBe 200
+            val response = it.parse<Map<String, Any>>()
+            response shouldContainAll claims
+            response shouldContain ("active" to true)
+        }
+    }
+
+    @Test
+    fun `introspect should return multiple audiences as array of strings`() {
+        val issuerUrl = "http://localhost/default"
+        val tokenProvider = OAuth2TokenProvider()
+        val claims =
+            mapOf(
+                "iss" to issuerUrl,
+                "client_id" to "yolo",
+                "token_type" to "token",
+                "sub" to "foo",
+                "aud" to listOf("audience1", "audience2"),
+            )
+        val token = tokenProvider.jwt(claims)
+        val request = request("$issuerUrl$INTROSPECT", token.serialize())
+
+        routes { introspect(tokenProvider) }.invoke(request).asClue {
+            it.status shouldBe 200
+            val response = it.parse<Map<String, Any>>()
+            response shouldContainAll claims
+            response shouldContain ("active" to true)
+        }
+    }
+
+    @Test
     fun `introspect should return active false when token is missing`() {
         val url = "http://localhost/default$INTROSPECT"
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
@@ -92,7 +92,7 @@ internal class IntrospectTest {
     }
 
     @Test
-    fun `introspect should return iat and exp from claims when provider`() {
+    fun `introspect should return iat and exp from claims when present in token`() {
         val issuerUrl = "http://localhost/default"
         val tokenProvider = OAuth2TokenProvider()
         val claims =


### PR DESCRIPTION
Nimbus processed the JWT claims set to convert the "well-known" values to more appropriate formats, causing the introspection mapping to always return null for the expiration time, issue time, and not before time as the cast to Long could never succeed.

I've also noticed that while the audience is not strictly required to be an array, the claims map it as such either way, so I've adjusted the type for this as well.