### PR TITLE
feat(build): use chainguard jre:latest-dev base image for docker healthcheck support

### DIFF
--- a/docker-compose-ssl.yaml
+++ b/docker-compose-ssl.yaml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   mock-oauth2-server:
     image: mock-oauth2-server:latest
@@ -11,3 +9,9 @@ services:
       LOG_LEVEL: "debug"
       SERVER_PORT: 8080
       JSON_CONFIG_PATH: /app/config.json
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/isalive" ]
+      start_period: 5s
+      retries: 10
+      interval: 2s
+      timeout: 1s

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: "3.1"
-
 services:
   mock-oauth2-server:
     image: mock-oauth2-server:latest
@@ -13,3 +11,9 @@ services:
       LOG_LEVEL: "debug"
       SERVER_PORT: 8080
       JSON_CONFIG_PATH: /app/config.json
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/isalive" ]
+      start_period: 5s
+      retries: 10
+      interval: 2s
+      timeout: 1s


### PR DESCRIPTION
Resolves #784, supersedes #811.

The `latest-dev` tag adds some utilities such as `wget` to the runtime environment, allowing us to continue using jib and not having to maintain a separate base image that would add `curl`. 

However, we do have to use the `latest` tags for the JRE here, which currently uses targets JRE 24 (and soon 25). I don't think it'll cause any issues, but it's something to be aware of.