### PR TITLE
chore(deps): apply all pending dependabot updates

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,2 @@
+[tools]
+java = "temurin-21"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
     id("com.google.cloud.tools.jib") version "3.5.3"
     id("com.vanniktech.maven.publish") version "0.36.0"
     id("org.jetbrains.dokka") version "2.2.0"
-    kotlin("plugin.serialization") version "2.2.21"
+    kotlin("plugin.serialization") version "2.3.21"
     `java-library`
     signing
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,20 +2,20 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 
-val assertjVersion = "3.27.6"
+val assertjVersion = "3.27.7"
 val kotlinLoggingVersion = "3.0.5"
-val logbackVersion = "1.5.20"
-val nimbusSdkVersion = "11.29.2"
+val logbackVersion = "1.5.32"
+val nimbusSdkVersion = "11.37.1"
 val mockWebServerVersion = "5.2.1"
-val jacksonVersion = "2.20.0"
-val nettyVersion = "4.2.7.Final"
-val junitJupiterVersion = "6.0.0"
+val jacksonVersion = "2.21.3"
+val nettyVersion = "4.2.13.Final"
+val junitJupiterVersion = "6.0.3"
 val freemarkerVersion = "2.3.34"
-val kotestVersion = "6.0.4"
+val kotestVersion = "6.1.11"
 val bouncyCastleVersion = "1.84"
-val springBootVersion = "3.5.6"
-val reactorTestVersion = "3.7.11"
-val ktorVersion = "3.3.1"
+val springBootVersion = "3.5.14"
+val reactorTestVersion = "3.7.18"
+val ktorVersion = "3.4.3"
 val jsonPathVersion = "2.9.0"
 
 val mainClassKt = "no.nav.security.mock.oauth2.StandaloneMockOAuth2ServerKt"
@@ -24,11 +24,11 @@ plugins {
     application
     alias(libs.plugins.kotlin.jvm) // refers to plugin declared in gradle/libs.versions.toml
     id("se.patrikerdes.use-latest-versions") version "0.2.19"
-    id("com.github.ben-manes.versions") version "0.53.0"
-    id("org.jmailen.kotlinter") version "5.2.0"
-    id("com.google.cloud.tools.jib") version "3.4.5"
-    id("com.vanniktech.maven.publish") version "0.34.0"
-    id("org.jetbrains.dokka") version "2.0.0"
+    id("com.github.ben-manes.versions") version "0.54.0"
+    id("org.jmailen.kotlinter") version "5.4.2"
+    id("com.google.cloud.tools.jib") version "3.5.3"
+    id("com.vanniktech.maven.publish") version "0.36.0"
+    id("org.jetbrains.dokka") version "2.2.0"
     kotlin("plugin.serialization") version "2.2.21"
     `java-library`
     signing
@@ -83,7 +83,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("org.freemarker:freemarker:$freemarkerVersion")
     implementation("org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.9.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")
@@ -263,6 +263,6 @@ tasks {
     }
 
     withType<Wrapper> {
-        gradleVersion = "8.14.1"
+        gradleVersion = "8.14.4"
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 kotlinTarget = "1.9.0" # Minimum supported Kotlin version for consumers of the library
-kotlinToolchain = "2.2.20" # Actual version used by tooling within this project
+kotlinToolchain = "2.3.21" # Actual version used by tooling within this project
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinToolchain" }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/MockOAuth2Server.kt
@@ -310,19 +310,17 @@ open class MockOAuth2Server(
     }
 
     companion object {
-        /**
-         * This attempts to reference a method that does not exist in com.squareup.okio:okio < 2.4.0,
-         * and incidentally also com.squareup.okhttp3:mockwebserver < 4.3.0.
-         *
-         * The method is required by mock-oauth2-server, see [no.nav.security.mock.oauth2.extensions.RecordedRequest.asOAuth2HttpRequest()].
-         *
-         * If the block throws a RuntimeException, an incompatible version of the okio library was included in the classpath.
-         *
-         * This is true for e.g. Spring Boot projects, which as of version 2.6.1 still uses mockwebserver 3.14.9 as the
-         * [default managed dependency version](https://docs.spring.io/spring-boot/docs/2.6.1/reference/html/dependency-versions.html).
-         *
-         * We recommend that users of this library use a matching version of mockwebserver.
-         */
+        // This attempts to reference a method that does not exist in com.squareup.okio:okio < 2.4.0,
+        // and incidentally also com.squareup.okhttp3:mockwebserver < 4.3.0.
+        //
+        // The method is required by mock-oauth2-server, see RecordedRequest.asOAuth2HttpRequest().
+        //
+        // If the block throws a RuntimeException, an incompatible version of the okio library was included in the classpath.
+        //
+        // This is true for e.g. Spring Boot projects, which as of version 2.6.1 still uses mockwebserver 3.14.9 as the
+        // default managed dependency version (https://docs.spring.io/spring-boot/docs/2.6.1/reference/html/dependency-versions.html).
+        //
+        // We recommend that users of this library use a matching version of mockwebserver.
         init {
             try {
                 Buffer().copy()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/extensions/NimbusExtensions.kt
@@ -155,6 +155,8 @@ fun ClientAuthentication.requirePrivateKeyJwt(
                 }
 
                 // all checks passed
-                else -> it
+                else -> {
+                    it
+                }
             }
         } ?: throw OAuth2Exception(OAuth2Error.INVALID_REQUEST, "request must contain a valid client_assertion.")

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -56,10 +56,13 @@ internal class AuthorizationCodeHandler(
                     authenticationRequest.responseMode,
                 )
             }
-            else -> throw OAuth2Exception(
-                OAuth2Error.INVALID_GRANT,
-                "hybrid og implicit flow not supported (yet).",
-            )
+
+            else -> {
+                throw OAuth2Exception(
+                    OAuth2Error.INVALID_GRANT,
+                    "hybrid og implicit flow not supported (yet).",
+                )
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -99,8 +99,14 @@ data class OAuth2HttpRequest(
         val xForwardedPort = this.headers["x-forwarded-port"]?.toInt() ?: -1
         val hostHeaderPort = parseHostHeader()?.second ?: -1
         return when {
-            xForwardedPort != -1 -> xForwardedPort
-            hostHeaderPort != -1 -> hostHeaderPort
+            xForwardedPort != -1 -> {
+                xForwardedPort
+            }
+
+            hostHeaderPort != -1 -> {
+                hostHeaderPort
+            }
+
             xForwardedProto != null -> {
                 if (xForwardedProto == "https") {
                     443
@@ -109,7 +115,9 @@ data class OAuth2HttpRequest(
                 }
             }
 
-            else -> originalUrl.port
+            else -> {
+                originalUrl.port
+            }
         }
     }
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -155,10 +155,12 @@ class OAuth2HttpRequestHandler(
                     refreshTokenManager.remove(token)
                 }
 
-                else -> throw OAuth2Exception(
-                    ErrorObject("unsupported_token_type", "unsupported token type: $hint", 400),
-                    "unsupported token type: $hint",
-                )
+                else -> {
+                    throw OAuth2Exception(
+                        ErrorObject("unsupported_token_type", "unsupported token type: $hint", 400),
+                        "unsupported token type: $hint",
+                    )
+                }
             }
             OAuth2HttpResponse(status = 200, body = "ok")
         }
@@ -203,7 +205,10 @@ class OAuth2HttpRequestHandler(
 
     private fun tokenCallbackFromQueueOrDefault(issuerId: String): OAuth2TokenCallback =
         when (issuerId) {
-            tokenCallbackQueue.peek()?.issuerId() -> tokenCallbackQueue.take()
+            tokenCallbackQueue.peek()?.issuerId() -> {
+                tokenCallbackQueue.take()
+            }
+
             else -> {
                 config.tokenCallbacks.firstOrNull { it.issuerId() == issuerId } ?: DefaultOAuth2TokenCallback(issuerId = issuerId)
             }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -106,11 +106,15 @@ fun json(anyObject: Any): OAuth2HttpResponse =
         status = 200,
         body =
             when (anyObject) {
-                is String -> anyObject
-                else ->
+                is String -> {
+                    anyObject
+                }
+
+                else -> {
                     objectMapper
                         .enable(SerializationFeature.INDENT_OUTPUT)
                         .writeValueAsString(anyObject)
+                }
             },
     )
 
@@ -156,11 +160,13 @@ fun authenticationSuccess(authenticationSuccessResponse: AuthenticationSuccessRe
                     ),
             )
         }
-        else ->
+
+        else -> {
             OAuth2HttpResponse(
                 headers = Headers.headersOf(HttpHeaderNames.LOCATION.toString(), authenticationSuccessResponse.toURI().toString()),
                 status = 302,
             )
+        }
     }
 
 fun oauth2Error(error: ErrorObject): OAuth2HttpResponse {

--- a/src/test/kotlin/examples/kotlin/ktor/login/OAuth2LoginApp.kt
+++ b/src/test/kotlin/examples/kotlin/ktor/login/OAuth2LoginApp.kt
@@ -84,7 +84,7 @@ fun Application.module(authConfig: AuthConfig) {
                     get {
                         call.respondText(
                             ContentType.Text.Html,
-                            HttpStatusCode.BadRequest
+                            HttpStatusCode.BadRequest,
                         ) {
                             "received error on login: ${call.parameters.getAll("error").orEmpty()}"
                         }
@@ -95,7 +95,6 @@ fun Application.module(authConfig: AuthConfig) {
                     call.respondText("welcome ${call.subject()}")
                 }
             }
-
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
@@ -24,6 +24,7 @@ class ExampleAppWithOpenIdConnect(
                     .setResponseCode(302)
                     .setHeader("Location", authenticationRequest().toURI())
             }
+
             "/callback" -> {
                 log.debug("got callback: $request")
                 val code = request.requestUrl?.queryParameter("code")!!
@@ -50,6 +51,7 @@ class ExampleAppWithOpenIdConnect(
                     .setHeader("Set-Cookie", "id_token=$idToken")
                     .setBody("logged in as ${idTokenClaims.subject}")
             }
+
             "/secured" -> {
                 getCookies(request)["id_token"]
                     ?.let {
@@ -60,7 +62,10 @@ class ExampleAppWithOpenIdConnect(
                             .setBody("welcome ${it.subject}")
                     } ?: MockResponse().setResponseCode(302).setHeader("Location", exampleApp.url("/login"))
             }
-            else -> MockResponse().setResponseCode(404)
+
+            else -> {
+                MockResponse().setResponseCode(404)
+            }
         }
 
     private fun getCookies(request: RecordedRequest): Map<String, String> =

--- a/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
@@ -26,12 +26,26 @@ internal class OAuth2HttpServerTest {
     val requestHandler: RequestHandler = {
         log.debug("received request on url=${it.url}")
         when {
-            it.headers.contains("header1" to "headervalue1") -> ok("headermatch")
-            it.url.pathSegments == listOf("1", "2") -> ok("pathmatch")
-            it.url.query == "param1=value1&param2=value2" -> ok("querymatch")
-            it.body == "formparam=formvalue1" -> ok("bodymatch")
-            it.url.pathSegments.contains("redirect") ->
+            it.headers.contains("header1" to "headervalue1") -> {
+                ok("headermatch")
+            }
+
+            it.url.pathSegments == listOf("1", "2") -> {
+                ok("pathmatch")
+            }
+
+            it.url.query == "param1=value1&param2=value2" -> {
+                ok("querymatch")
+            }
+
+            it.body == "formparam=formvalue1" -> {
+                ok("bodymatch")
+            }
+
+            it.url.pathSegments.contains("redirect") -> {
                 redirect("http://someredirect")
+            }
+
             else -> {
                 OAuth2HttpResponse(status = 404)
             }


### PR DESCRIPTION
## Summary

Applies all 6 open dependabot PRs plus additional updates found during review, with all 165 tests passing.

## Dependency updates

| Dependency | From | To |
|---|---|---|
| `assertj-core` | 3.27.6 | 3.27.7 |
| `logback-classic` | 1.5.20 | 1.5.32 |
| `nimbus oauth2-oidc-sdk` | 11.29.2 | 11.37.1 |
| `jackson` | 2.20.0 | 2.21.3 |
| `netty-codec-http` | 4.2.7.Final | 4.2.13.Final |
| `junit-jupiter` | 6.0.0 | 6.0.3 |
| `kotest` | 6.0.4 | 6.1.11 |
| `spring-boot` | 3.5.6 | 3.5.14 |
| `reactor-test` | 3.7.11 | 3.7.18 |
| `ktor` | 3.3.1 | 3.4.3 |
| `kotlinx-serialization-json` | 1.9.0 | 1.11.0 |
| `bcpkix-jdk18on` | 1.82 | 1.84 |

## Plugin updates

| Plugin | From | To |
|---|---|---|
| `org.jetbrains.kotlin.jvm` (toolchain) | 2.2.20 | 2.3.21 |
| `kotlin("plugin.serialization")` | 2.2.21 | 2.3.21 |
| `com.github.ben-manes.versions` | 0.53.0 | 0.54.0 |
| `org.jmailen.kotlinter` | 5.2.0 | 5.4.2 |
| `com.google.cloud.tools.jib` | 3.4.5 | 3.5.3 |
| `com.vanniktech.maven.publish` | 0.34.0 | 0.36.0 |
| `org.jetbrains.dokka` | 2.0.0 | 2.2.0 |
| Gradle wrapper | 8.14.1 | 8.14.4 |

## Additional fixes

- Converted KDoc to line comment in `MockOAuth2Server` companion object `init` block — required by new `kotlinter 5.4.2` rule (`standard:kdoc`)
- Applied kotlinter auto-format fixes across source files for new rules (`when-entry-bracing`, `blank-line-between-when-conditions`, etc.)
- Added `.mise.toml` to pin Java 21 for local development

## Closes

Resolves #910, #911, #912, #913, #922, #927