### PR TITLE
fix: set dependency-graph-continue-on-failure to true in build-master workflow

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -24,6 +24,8 @@ jobs:
         uses: gradle/actions/setup-gradle@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # ratchet:gradle/actions/setup-gradle@v4
       - name: Generate and submit dependency graph
         uses: gradle/actions/dependency-submission@f29f5a9d7b09a7c6b29859002d29d24e1674c884 # ratchet:gradle/actions/dependency-submission@v4
+        with:
+          dependency-graph-continue-on-failure: true
       - name: Build with Gradle
         run: ./gradlew build
   release-notes:


### PR DESCRIPTION
## Problem

The `Build master` workflow was failing due to a transient GitHub API error when submitting the dependency graph:

```
HttpError: Dependency submission failed for dependency-graph-reports/build_master-build.json.
An error occurred while processing your request. Please try again later.
```

The build itself succeeds — this is purely a GitHub-side infrastructure hiccup on the dependency submission API.

## Fix

Set `dependency-graph-continue-on-failure: true` on the `gradle/actions/dependency-submission` step so that transient API failures do not block the build workflow.