### PR TITLE
fix(ci): migrate dokka task from V1 to V2 API

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -28,7 +28,7 @@ jobs:
         run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
 
       - name: Build Dokka
-        run: ./gradlew dokkaHtm -Pversion=${{ env.VERSION }}
+        run: ./gradlew dokkaGenerateHtml -Pversion=${{ env.VERSION }}
 
       - name: Publish documentation
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # ratchet:JamesIves/github-pages-deploy-action@v4.8.0


### PR DESCRIPTION
## Problem

The `Build Docs` workflow was failing after upgrading `org.jetbrains.dokka` to `2.2.0`:

\`\`\`
Cannot run Dokka V1 tasks when V2 mode is enabled.
Dokka Gradle plugin V1 mode is deprecated, and scheduled to be removed in Dokka v2.2.0.
\`\`\`

## Fix

Replace the deprecated `dokkaHtm` task (which also had a typo — missing the `l`) with the V2 equivalent `dokkaGenerateHtml`. The output directory `build/dokka/html` remains unchanged.