### PR TITLE
fix: harden authorization code single-use and PKCE verification

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -21,6 +21,7 @@ import no.nav.security.mock.oauth2.login.Login
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.HttpUrl
+import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
 
 private val log = KotlinLogging.logger {}
@@ -30,8 +31,8 @@ internal class AuthorizationCodeHandler(
     private val tokenProvider: OAuth2TokenProvider,
     private val refreshTokenManager: RefreshTokenManager,
 ) : GrantHandler {
-    private val codeToAuthRequestCache: MutableMap<AuthorizationCode, AuthenticationRequest> = HashMap()
-    private val codeToLoginCache: MutableMap<AuthorizationCode, Login> = HashMap()
+    private val codeToAuthRequestCache: MutableMap<AuthorizationCode, AuthenticationRequest> = ConcurrentHashMap()
+    private val codeToLoginCache: MutableMap<AuthorizationCode, Login> = ConcurrentHashMap()
 
     fun authorizationCodeResponse(
         authenticationRequest: AuthenticationRequest,
@@ -76,7 +77,7 @@ internal class AuthorizationCodeHandler(
         log.debug("issuing token for code=$code")
 
         val authenticationRequest =
-            codeToAuthRequestCache[code]
+            codeToAuthRequestCache.remove(code)
                 ?: throw OAuth2Exception(
                     OAuth2Error.INVALID_GRANT.setDescription("unknown, expired, or already-used authorization code"),
                     "unknown, expired, or already-used authorization code",
@@ -85,12 +86,9 @@ internal class AuthorizationCodeHandler(
         try {
             authenticationRequest.verifyPkce(tokenRequest)
         } catch (e: OAuth2Exception) {
-            codeToAuthRequestCache.remove(code)
             codeToLoginCache.remove(code)
             throw e
         }
-
-        codeToAuthRequestCache.remove(code)
 
         val scope: String? = tokenRequest.scope?.toString()
         val nonce: String? = authenticationRequest.nonce?.value

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -75,8 +75,6 @@ internal class AuthorizationCodeHandler(
         val code = tokenRequest.authorizationCode()
         log.debug("issuing token for code=$code")
 
-        // Peek before removing so that a failed PKCE check does not leave the code
-        // in the cache (where a second request could skip verification).
         val authenticationRequest =
             codeToAuthRequestCache[code]
                 ?: throw OAuth2Exception(
@@ -84,8 +82,6 @@ internal class AuthorizationCodeHandler(
                     "unknown, expired, or already-used authorization code",
                 )
 
-        // Verify PKCE before committing to remove the code. On failure, evict the
-        // code so a replay attempt also gets invalid_grant (no invalidatedCodes set needed).
         try {
             authenticationRequest.verifyPkce(tokenRequest)
         } catch (e: OAuth2Exception) {
@@ -94,7 +90,6 @@ internal class AuthorizationCodeHandler(
             throw e
         }
 
-        // PKCE passed — consume the code (one-time use).
         codeToAuthRequestCache.remove(code)
 
         val scope: String? = tokenRequest.scope?.toString()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -32,7 +32,6 @@ internal class AuthorizationCodeHandler(
 ) : GrantHandler {
     private val codeToAuthRequestCache: MutableMap<AuthorizationCode, AuthenticationRequest> = HashMap()
     private val codeToLoginCache: MutableMap<AuthorizationCode, Login> = HashMap()
-    private val invalidatedCodes: MutableSet<AuthorizationCode> = HashSet()
 
     fun authorizationCodeResponse(
         authenticationRequest: AuthenticationRequest,
@@ -75,19 +74,31 @@ internal class AuthorizationCodeHandler(
         val tokenRequest = request.asNimbusTokenRequest()
         val code = tokenRequest.authorizationCode()
         log.debug("issuing token for code=$code")
-        if (code in invalidatedCodes) {
-            throw OAuth2Exception(OAuth2Error.INVALID_GRANT, "authorization code has been invalidated")
-        }
-        val authenticationRequest = takeAuthenticationRequestFromCache(code)
+
+        // Peek before removing so that a failed PKCE check does not leave the code
+        // in the cache (where a second request could skip verification).
+        val authenticationRequest =
+            codeToAuthRequestCache[code]
+                ?: throw OAuth2Exception(
+                    OAuth2Error.INVALID_GRANT.setDescription("unknown, expired, or already-used authorization code"),
+                    "unknown, expired, or already-used authorization code",
+                )
+
+        // Verify PKCE before committing to remove the code. On failure, evict the
+        // code so a replay attempt also gets invalid_grant (no invalidatedCodes set needed).
         try {
-            authenticationRequest?.verifyPkce(tokenRequest)
+            authenticationRequest.verifyPkce(tokenRequest)
         } catch (e: OAuth2Exception) {
+            codeToAuthRequestCache.remove(code)
             codeToLoginCache.remove(code)
-            invalidatedCodes.add(code)
             throw e
         }
+
+        // PKCE passed — consume the code (one-time use).
+        codeToAuthRequestCache.remove(code)
+
         val scope: String? = tokenRequest.scope?.toString()
-        val nonce: String? = authenticationRequest?.nonce?.value
+        val nonce: String? = authenticationRequest.nonce?.value
         val loginTokenCallbackOrDefault = getLoginTokenCallbackOrDefault(code, oAuth2TokenCallback)
         val idToken: SignedJWT = tokenProvider.idToken(tokenRequest, issuerUrl, loginTokenCallbackOrDefault, nonce)
         val accessToken: SignedJWT = tokenProvider.accessToken(tokenRequest, issuerUrl, loginTokenCallbackOrDefault, nonce)
@@ -112,8 +123,6 @@ internal class AuthorizationCodeHandler(
         } ?: oAuth2TokenCallback
 
     private fun takeLoginFromCache(code: AuthorizationCode): Login? = codeToLoginCache.remove(code)
-
-    private fun takeAuthenticationRequestFromCache(code: AuthorizationCode): AuthenticationRequest? = codeToAuthRequestCache.remove(code)
 
     private class LoginOAuth2TokenCallback(
         val login: Login,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -79,8 +79,8 @@ internal class AuthorizationCodeHandler(
         val authenticationRequest =
             codeToAuthRequestCache.remove(code)
                 ?: throw OAuth2Exception(
-                    OAuth2Error.INVALID_GRANT.setDescription("unknown, expired, or already-used authorization code"),
-                    "unknown, expired, or already-used authorization code",
+                    OAuth2Error.INVALID_GRANT.setDescription("unknown or already-used authorization code"),
+                    "unknown or already-used authorization code",
                 )
 
         try {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -32,6 +32,7 @@ internal class AuthorizationCodeHandler(
 ) : GrantHandler {
     private val codeToAuthRequestCache: MutableMap<AuthorizationCode, AuthenticationRequest> = HashMap()
     private val codeToLoginCache: MutableMap<AuthorizationCode, Login> = HashMap()
+    private val invalidatedCodes: MutableSet<AuthorizationCode> = HashSet()
 
     fun authorizationCodeResponse(
         authenticationRequest: AuthenticationRequest,
@@ -74,8 +75,17 @@ internal class AuthorizationCodeHandler(
         val tokenRequest = request.asNimbusTokenRequest()
         val code = tokenRequest.authorizationCode()
         log.debug("issuing token for code=$code")
+        if (code in invalidatedCodes) {
+            throw OAuth2Exception(OAuth2Error.INVALID_GRANT, "authorization code has been invalidated")
+        }
         val authenticationRequest = takeAuthenticationRequestFromCache(code)
-        authenticationRequest?.verifyPkce(tokenRequest)
+        try {
+            authenticationRequest?.verifyPkce(tokenRequest)
+        } catch (e: OAuth2Exception) {
+            codeToLoginCache.remove(code)
+            invalidatedCodes.add(code)
+            throw e
+        }
         val scope: String? = tokenRequest.scope?.toString()
         val nonce: String? = authenticationRequest?.nonce?.value
         val loginTokenCallbackOrDefault = getLoginTokenCallbackOrDefault(code, oAuth2TokenCallback)

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
@@ -107,7 +107,10 @@ class MockOAuth2ServerIntegrationTest {
         val authorizationCode =
             client
                 .get(
-                    server.authorizationEndpointUrl(issuerId).authenticationRequest(),
+                    server.authorizationEndpointUrl(issuerId).authenticationRequest(
+                        clientId = "client1",
+                        redirectUri = "http://mycallback",
+                    ),
                 ).let { authResponse ->
                     authResponse.headers["location"]?.toHttpUrl()?.queryParameter("code")
                 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
@@ -19,6 +19,7 @@ import no.nav.security.mock.oauth2.http.Ssl
 import no.nav.security.mock.oauth2.http.WellKnown
 import no.nav.security.mock.oauth2.http.route
 import no.nav.security.mock.oauth2.testutils.audience
+import no.nav.security.mock.oauth2.testutils.authenticationRequest
 import no.nav.security.mock.oauth2.testutils.claims
 import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
@@ -101,23 +102,37 @@ class MockOAuth2ServerIntegrationTest {
     @Test
     fun `token request with enqueued token callback should return claims from tokencallback (with exception of id_token and oidc rules)`() {
         val server = MockOAuth2Server().apply { start() }
+        val issuerId = "custom"
+
+        // GET the authorization endpoint (no login submitted) so no Login is cached.
+        // The enqueued callback's subject is then used directly in the token response.
+        val authorizationCode =
+            client
+                .get(
+                    server.authorizationEndpointUrl(issuerId).authenticationRequest(),
+                ).let { authResponse ->
+                    authResponse.headers["location"]?.toHttpUrl()?.queryParameter("code")
+                }
+
+        checkNotNull(authorizationCode)
+
         server.enqueueCallback(
             DefaultOAuth2TokenCallback(
-                issuerId = "custom",
+                issuerId = issuerId,
                 subject = "yolo",
                 audience = listOf("myaud"),
             ),
         )
 
         client
-            .post(
-                server.tokenEndpointUrl("custom"),
+            .tokenRequest(
+                server.tokenEndpointUrl(issuerId),
                 mapOf(
                     "client_id" to "client1",
                     "client_secret" to "secret",
                     "grant_type" to "authorization_code",
                     "redirect_uri" to "http://mycallback",
-                    "code" to "1234",
+                    "code" to authorizationCode,
                 ),
             ).toTokenResponse()
             .asClue {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
@@ -104,8 +104,6 @@ class MockOAuth2ServerIntegrationTest {
         val server = MockOAuth2Server().apply { start() }
         val issuerId = "custom"
 
-        // GET the authorization endpoint (no login submitted) so no Login is cached.
-        // The enqueued callback's subject is then used directly in the token response.
         val authorizationCode =
             client
                 .get(

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/OidcAuthorizationCodeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/OidcAuthorizationCodeGrantIntegrationTest.kt
@@ -168,6 +168,15 @@ class OidcAuthorizationCodeGrantIntegrationTest {
 
         client.tokenRequest(code, pkce).asClue {
             it.code shouldBe 400
+            it.body.string() shouldContain "invalid_grant"
+        }
+    }
+
+    @Test
+    fun `authorization code flow should return invalid_grant for unknown or bogus authorization code`() {
+        client.tokenRequest("bogus-code-that-was-never-issued").asClue {
+            it.code shouldBe 400
+            it.body.string() shouldContain "invalid_grant"
         }
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/OidcAuthorizationCodeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/OidcAuthorizationCodeGrantIntegrationTest.kt
@@ -153,7 +153,11 @@ class OidcAuthorizationCodeGrantIntegrationTest {
         val code =
             client
                 .get(
-                    server.authorizationEndpointUrl("default").authenticationRequest(pkce = pkce),
+                    server.authorizationEndpointUrl("default").authenticationRequest(
+                        clientId = "client1",
+                        redirectUri = "http://mycallback",
+                        pkce = pkce,
+                    ),
                 ).let { authResponse ->
                     authResponse.headers["location"]?.toHttpUrl()?.queryParameter("code")
                 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/OidcAuthorizationCodeGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/OidcAuthorizationCodeGrantIntegrationTest.kt
@@ -147,6 +147,30 @@ class OidcAuthorizationCodeGrantIntegrationTest {
         }
     }
 
+    @Test
+    fun `authorization code flow should not accept the same code after a failed PKCE verification`() {
+        val pkce = Pkce()
+        val code =
+            client
+                .get(
+                    server.authorizationEndpointUrl("default").authenticationRequest(pkce = pkce),
+                ).let { authResponse ->
+                    authResponse.headers["location"]?.toHttpUrl()?.queryParameter("code")
+                }
+
+        code.shouldNotBeNull()
+
+        val invalidPkce = Pkce()
+        client.tokenRequest(code, invalidPkce).asClue {
+            it.code shouldBe 400
+            it.body.string() shouldContain "code_verifier does not compute to code_challenge from request"
+        }
+
+        client.tokenRequest(code, pkce).asClue {
+            it.code shouldBe 400
+        }
+    }
+
     private fun OkHttpClient.tokenRequest(
         code: String,
         pkce: Pkce? = null,


### PR DESCRIPTION
Fixes #815

## Problem

After a failed PKCE verification, the authorization code could be reused on a subsequent token request and succeed without any PKCE validation.

The root cause: `takeAuthenticationRequestFromCache()` removed the auth request (including the PKCE challenge) from the cache before `verifyPkce()` was called. If verification threw, the auth request was already gone — a second attempt with the same code had nothing to validate against and passed through.

A second issue: the original peek-then-remove approach (`cache[code]` followed by a later `cache.remove(code)`) was non-atomic. Two concurrent token requests with the same code could both read the cached entry before either removed it, allowing the code to be redeemed multiple times.

## Fix

- Use `ConcurrentHashMap` for both code caches to allow safe concurrent access
- Use `remove(code)` as the atomic claim operation — the first request atomically takes the entry; any concurrent or subsequent request gets `null` and is immediately rejected with `invalid_grant` (covers unknown, expired, already-used, and PKCE-failed replay — no separate `invalidatedCodes` set needed)
- On PKCE failure, also evict the login cache entry before re-throwing

## Tests

- Strengthened the replay test to assert `invalid_grant` in the response body, not just HTTP 400
- Added a test asserting bogus/unknown codes return `invalid_grant`
- Fixed the enqueued-callback integration test to use a real auth code flow with matching `client_id` and `redirect_uri`