### PR TITLE
fix: match requestMappings when client_id is provided via HTTP Basic auth

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -113,8 +113,16 @@ data class RequestMapping(
     val claims: Map<String, Any> = emptyMap(),
     val typeHeader: String = JOSEObjectType.JWT.type,
 ) {
-    fun isMatch(tokenRequest: TokenRequest): Boolean =
-        tokenRequest.toHTTPRequest().bodyAsFormParameters[requestParam]?.any {
+    fun isMatch(tokenRequest: TokenRequest): Boolean {
+        val formValues = tokenRequest.toHTTPRequest().bodyAsFormParameters[requestParam]
+        val effectiveValues =
+            if (formValues == null && requestParam == "client_id") {
+                tokenRequest.clientIdAsString()?.let { listOf(it) }
+            } else {
+                formValues
+            }
+        return effectiveValues?.any {
             match == "*" || match == it || match.toRegex().matchEntire(it) != null
         } ?: false
+    }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -117,7 +117,8 @@ data class RequestMapping(
         val formValues = tokenRequest.toHTTPRequest().bodyAsFormParameters[requestParam]
         val effectiveValues =
             if (formValues == null && requestParam == "client_id") {
-                tokenRequest.clientIdAsString()?.let { listOf(it) }
+                tokenRequest.clientAuthentication?.clientID?.value?.let { listOf(it) }
+                    ?: tokenRequest.clientID?.value?.let { listOf(it) }
             } else {
                 formValues
             }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
@@ -213,6 +213,23 @@ class MockOAuth2ServerIntegrationTest {
             }
     }
 
+    @Test
+    fun `token request with client_id via HTTP Basic auth should match requestmapping on client_id`() {
+        val server = MockOAuth2Server(OAuth2Config.fromJson(clientIdMappingConfigJson)).apply { start() }
+        client
+            .tokenRequest(
+                server.tokenEndpointUrl("issuer1"),
+                "client1" to "secret",
+                mapOf("grant_type" to "client_credentials"),
+            ).toTokenResponse()
+            .accessToken
+            .asClue {
+                it.shouldNotBeNull()
+                it.claims shouldContainAll mapOf("sub" to "subByClientId", "aud" to listOf("audByClientId"))
+            }
+        server.shutdown()
+    }
+
     private infix fun WellKnown.urlsShouldStartWith(url: String) {
         issuer shouldStartWith url
         authorizationEndpoint shouldStartWith url
@@ -255,6 +272,29 @@ class MockOAuth2ServerIntegrationTest {
                     "aud": [
                       "audBySomeParam"
                     ]
+                  }
+                }
+              ]
+            }
+          ]
+        }
+        """.trimIndent()
+
+    @Language("json")
+    private val clientIdMappingConfigJson =
+        """
+        {
+          "httpServer": "MockWebServerWrapper",
+          "tokenCallbacks": [
+            {
+              "issuerId": "issuer1",
+              "requestMappings": [
+                {
+                  "requestParam": "client_id",
+                  "match": "client1",
+                  "claims": {
+                    "sub": "subByClientId",
+                    "aud": ["audByClientId"]
                   }
                 }
               ]

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/MockOAuth2ServerIntegrationTest.kt
@@ -215,19 +215,19 @@ class MockOAuth2ServerIntegrationTest {
 
     @Test
     fun `token request with client_id via HTTP Basic auth should match requestmapping on client_id`() {
-        val server = MockOAuth2Server(OAuth2Config.fromJson(clientIdMappingConfigJson)).apply { start() }
-        client
-            .tokenRequest(
-                server.tokenEndpointUrl("issuer1"),
-                "client1" to "secret",
-                mapOf("grant_type" to "client_credentials"),
-            ).toTokenResponse()
-            .accessToken
-            .asClue {
-                it.shouldNotBeNull()
-                it.claims shouldContainAll mapOf("sub" to "subByClientId", "aud" to listOf("audByClientId"))
-            }
-        server.shutdown()
+        withMockOAuth2Server(config = OAuth2Config.fromJson(clientIdMappingConfigJson)) {
+            client
+                .tokenRequest(
+                    tokenEndpointUrl("issuer1"),
+                    "client1" to "secret",
+                    mapOf("grant_type" to "client_credentials"),
+                ).toTokenResponse()
+                .accessToken
+                .asClue {
+                    it.shouldNotBeNull()
+                    it.claims shouldContainAll mapOf("sub" to "subByClientId", "aud" to listOf("audByClientId"))
+                }
+        }
     }
 
     private infix fun WellKnown.urlsShouldStartWith(url: String) {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -115,6 +115,46 @@ internal class OAuth2TokenCallbackTest {
         }
 
         @Test
+        fun `token request with client_id via HTTP Basic auth should match requestmapping on client_id`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "client_id",
+                                match = clientId,
+                                claims = mapOf("sub" to "subByClientId", "aud" to listOf("audByClientId")),
+                            ),
+                        ),
+                )
+            val requestWithBasicAuth = clientCredentialsRequest()
+            assertSoftly {
+                callback.subject(requestWithBasicAuth) shouldBe "subByClientId"
+                callback.audience(requestWithBasicAuth) shouldBe listOf("audByClientId")
+            }
+        }
+
+        @Test
+        fun `token request with client_id via HTTP Basic auth and wildcard requestmapping should match`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "client_id",
+                                match = "*",
+                                claims = mapOf("sub" to "wildcardSub"),
+                            ),
+                        ),
+                )
+            assertSoftly {
+                callback.subject(clientCredentialsRequest()) shouldBe "wildcardSub"
+            }
+        }
+
+        @Test
         fun `token request with request params matching requestmapping should return specific claims from callback with audience`() {
             val grantTypeShouldMatch = clientCredentialsRequest("audience" to "https://myapp.com/jwt/aud/xxx")
             assertSoftly {


### PR DESCRIPTION
Fixes #825

## Problem

`RequestMapping.isMatch()` only looked at `bodyAsFormParameters`, so when `client_id` was provided via HTTP Basic auth (extracted by Nimbus from the `Authorization` header), it was never present in the form body. This caused all `requestMappings` with `requestParam = "client_id"` to silently fail, and configured claims were never applied.

Note: `getClaims()` already handled this correctly for value interpolation, the bug was only in `isMatch()`.

## Fix

When `bodyAsFormParameters[requestParam]` is `null` and `requestParam == "client_id"`, fall back to reading `clientAuthentication?.clientID?.value` or `clientID?.value` directly from the Nimbus `TokenRequest`. This avoids using `clientIdAsString()` which throws when `client_id` is absent, and instead returns `null` safely, causing `isMatch` to return `false` rather than throw.

## Tests

- Unit test: Basic auth `client_id` matches exact `requestParam = "client_id"` mapping
- Unit test: Basic auth `client_id` matches wildcard `match = "*"` mapping
- Integration test: full `client_credentials` flow via HTTP Basic auth returns claims from `requestMappings`
- Integration test uses `withMockOAuth2Server` helper to guarantee server shutdown even if an assertion throws