### PR TITLE
fix: reject unknown and revoked refresh tokens with invalid_grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,3 +623,37 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more details.
 ## ⚖️ License
 
 This library is licensed under the [MIT License](LICENSE.md).
+
+---
+
+## Migration guide
+
+### Migrating to 4.0.0
+
+#### Refresh token validation is now strict
+
+Previously, any arbitrary string passed as a `refresh_token` was silently accepted and used to mint a new token via the default callback. This has been fixed: unknown, expired, and revoked refresh tokens now fail with `400 invalid_grant`.
+
+**What this means for existing tests:**
+
+- Tests that passed a hardcoded or arbitrary string as `refresh_token` will now receive `400 invalid_grant` instead of a valid token response. Use a real refresh token obtained from a prior token request.
+- Tests that relied on refresh succeeding after revocation will now fail. This is the correct behavior.
+- Tests that presented a refresh token issued by issuer A to issuer B will now receive `400 invalid_grant`.
+
+**Example migration:**
+
+```kotlin
+// Before: arbitrary string was accepted
+val response = client.post(server.tokenEndpointUrl("default")) {
+    body = "grant_type=refresh_token&refresh_token=any-string"
+}
+
+// After: obtain a real refresh token first
+val tokenResponse = client.post(server.tokenEndpointUrl("default")) {
+    body = "grant_type=authorization_code&code=..."
+}
+val refreshToken = tokenResponse.body.refresh_token
+val response = client.post(server.tokenEndpointUrl("default")) {
+    body = "grant_type=refresh_token&refresh_token=$refreshToken"
+}
+```

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenGrantHandler.kt
@@ -32,8 +32,12 @@ internal class RefreshTokenGrantHandler(
         var refreshToken = tokenRequest.refreshTokenGrant().refreshToken.value
         log.debug("issuing token for refreshToken=$refreshToken")
         val scope: String? = tokenRequest.scope?.toString()
-        val enqueuedCallback = enqueuedCallbackSupplier?.invoke(issuerUrl.issuerId())
+        val issuerId = issuerUrl.issuerId()
+        val enqueuedCallback = enqueuedCallbackSupplier?.invoke(issuerId)
         val storedCallback = refreshTokenManager[refreshToken]
+        if (storedCallback != null && storedCallback.issuerId() != issuerId) {
+            throw OAuth2Exception(OAuth2Error.INVALID_GRANT.setDescription("refresh_token was issued by a different issuer"), "refresh_token issuer mismatch")
+        }
         val resolvedCallback =
             enqueuedCallback
                 ?: storedCallback

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenGrantHandler.kt
@@ -2,13 +2,15 @@ package no.nav.security.mock.oauth2.grant
 
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.GrantType
+import com.nimbusds.oauth2.sdk.OAuth2Error
 import com.nimbusds.oauth2.sdk.RefreshTokenGrant
 import com.nimbusds.oauth2.sdk.TokenRequest
 import mu.KotlinLogging
+import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.expiresIn
+import no.nav.security.mock.oauth2.extensions.issuerId
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
-import no.nav.security.mock.oauth2.invalidGrant
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.HttpUrl
@@ -19,6 +21,7 @@ internal class RefreshTokenGrantHandler(
     private val tokenProvider: OAuth2TokenProvider,
     private val refreshTokenManager: RefreshTokenManager,
     private val rotateRefreshToken: Boolean = false,
+    private val enqueuedCallbackSupplier: ((issuerId: String) -> OAuth2TokenCallback?)? = null,
 ) : GrantHandler {
     override fun tokenResponse(
         request: OAuth2HttpRequest,
@@ -29,12 +32,17 @@ internal class RefreshTokenGrantHandler(
         var refreshToken = tokenRequest.refreshTokenGrant().refreshToken.value
         log.debug("issuing token for refreshToken=$refreshToken")
         val scope: String? = tokenRequest.scope?.toString()
-        val refreshTokenCallbackOrDefault = refreshTokenManager[refreshToken] ?: oAuth2TokenCallback
+        val enqueuedCallback = enqueuedCallbackSupplier?.invoke(issuerUrl.issuerId())
+        val storedCallback = refreshTokenManager[refreshToken]
+        val resolvedCallback =
+            enqueuedCallback
+                ?: storedCallback
+                ?: throw OAuth2Exception(OAuth2Error.INVALID_GRANT.setDescription("unknown refresh_token"), "unknown refresh_token")
         if (rotateRefreshToken) {
-            refreshToken = refreshTokenManager.rotate(refreshToken, refreshTokenCallbackOrDefault)
+            refreshToken = refreshTokenManager.rotate(refreshToken, resolvedCallback)
         }
-        val idToken: SignedJWT = tokenProvider.idToken(tokenRequest, issuerUrl, refreshTokenCallbackOrDefault)
-        val accessToken: SignedJWT = tokenProvider.accessToken(tokenRequest, issuerUrl, refreshTokenCallbackOrDefault)
+        val idToken: SignedJWT = tokenProvider.idToken(tokenRequest, issuerUrl, resolvedCallback)
+        val accessToken: SignedJWT = tokenProvider.accessToken(tokenRequest, issuerUrl, resolvedCallback)
 
         return OAuth2TokenResponse(
             tokenType = "Bearer",
@@ -46,5 +54,7 @@ internal class RefreshTokenGrantHandler(
         )
     }
 
-    private fun TokenRequest.refreshTokenGrant(): RefreshTokenGrant = (this.authorizationGrant as? RefreshTokenGrant) ?: invalidGrant(GrantType.REFRESH_TOKEN)
+    private fun TokenRequest.refreshTokenGrant(): RefreshTokenGrant =
+        (this.authorizationGrant as? RefreshTokenGrant)
+            ?: throw OAuth2Exception(OAuth2Error.INVALID_GRANT.setDescription("grant_type ${GrantType.REFRESH_TOKEN} not supported."), "grant_type ${GrantType.REFRESH_TOKEN} not supported.")
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenGrantHandler.kt
@@ -33,11 +33,11 @@ internal class RefreshTokenGrantHandler(
         log.debug("issuing token for refreshToken=$refreshToken")
         val scope: String? = tokenRequest.scope?.toString()
         val issuerId = issuerUrl.issuerId()
-        val enqueuedCallback = enqueuedCallbackSupplier?.invoke(issuerId)
         val storedCallback = refreshTokenManager[refreshToken]
         if (storedCallback != null && storedCallback.issuerId() != issuerId) {
             throw OAuth2Exception(OAuth2Error.INVALID_GRANT.setDescription("refresh_token was issued by a different issuer"), "refresh_token issuer mismatch")
         }
+        val enqueuedCallback = enqueuedCallbackSupplier?.invoke(issuerId)
         val resolvedCallback =
             enqueuedCallback
                 ?: storedCallback

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenManager.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/RefreshTokenManager.kt
@@ -4,12 +4,13 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.PlainJWT
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 
 typealias RefreshToken = String
 typealias Nonce = String
 
 internal data class RefreshTokenManager(
-    private val cache: MutableMap<RefreshToken, OAuth2TokenCallback> = HashMap(),
+    private val cache: MutableMap<RefreshToken, OAuth2TokenCallback> = ConcurrentHashMap(),
 ) {
     operator fun get(refreshToken: RefreshToken) = cache[refreshToken]
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -68,7 +68,9 @@ class OAuth2HttpRequestHandler(
             JWT_BEARER to JwtBearerGrantHandler(config.tokenProvider),
             TOKEN_EXCHANGE to TokenExchangeGrantHandler(config.tokenProvider),
             REFRESH_TOKEN to RefreshTokenGrantHandler(config.tokenProvider, refreshTokenManager, config.rotateRefreshToken) { issuerId ->
-                if (tokenCallbackQueue.peek()?.issuerId() == issuerId) tokenCallbackQueue.take() else null
+                synchronized(tokenCallbackQueue) {
+                    if (tokenCallbackQueue.peek()?.issuerId() == issuerId) tokenCallbackQueue.poll() else null
+                }
             },
             PASSWORD to PasswordGrantHandler(config.tokenProvider),
         )
@@ -213,14 +215,13 @@ class OAuth2HttpRequestHandler(
 
     private fun Route.Builder.preflight() = options { OAuth2HttpResponse(status = 204) }
 
-    private fun tokenCallbackFromQueueOrDefault(issuerId: String): OAuth2TokenCallback =
-        when (issuerId) {
-            tokenCallbackQueue.peek()?.issuerId() -> {
-                tokenCallbackQueue.take()
+    private fun tokenCallbackFromQueueOrDefault(issuerId: String): OAuth2TokenCallback {
+        val queued =
+            synchronized(tokenCallbackQueue) {
+                if (tokenCallbackQueue.peek()?.issuerId() == issuerId) tokenCallbackQueue.poll() else null
             }
-
-            else -> {
-                config.tokenCallbacks.firstOrNull { it.issuerId() == issuerId } ?: DefaultOAuth2TokenCallback(issuerId = issuerId)
-            }
-        }
+        return queued
+            ?: config.tokenCallbacks.firstOrNull { it.issuerId() == issuerId }
+            ?: DefaultOAuth2TokenCallback(issuerId = issuerId)
+    }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -67,7 +67,9 @@ class OAuth2HttpRequestHandler(
             CLIENT_CREDENTIALS to ClientCredentialsGrantHandler(config.tokenProvider),
             JWT_BEARER to JwtBearerGrantHandler(config.tokenProvider),
             TOKEN_EXCHANGE to TokenExchangeGrantHandler(config.tokenProvider),
-            REFRESH_TOKEN to RefreshTokenGrantHandler(config.tokenProvider, refreshTokenManager, config.rotateRefreshToken),
+            REFRESH_TOKEN to RefreshTokenGrantHandler(config.tokenProvider, refreshTokenManager, config.rotateRefreshToken) { issuerId ->
+                if (tokenCallbackQueue.peek()?.issuerId() == issuerId) tokenCallbackQueue.take() else null
+            },
             PASSWORD to PasswordGrantHandler(config.tokenProvider),
         )
 
@@ -173,7 +175,16 @@ class OAuth2HttpRequestHandler(
             post(TOKEN) {
                 log.debug("handle token request $it")
                 val grantType = it.grantType()
-                val tokenCallback: OAuth2TokenCallback = tokenCallbackFromQueueOrDefault(it.url.issuerId())
+                val issuerId = it.url.issuerId()
+                // For refresh_token grants the handler resolves the callback itself (stored vs enqueued priority).
+                // For all other grants consume from queue or fall back to config default.
+                val tokenCallback: OAuth2TokenCallback =
+                    if (grantType == REFRESH_TOKEN) {
+                        config.tokenCallbacks.firstOrNull { cb -> cb.issuerId() == issuerId }
+                            ?: DefaultOAuth2TokenCallback(issuerId = issuerId)
+                    } else {
+                        tokenCallbackFromQueueOrDefault(issuerId)
+                    }
                 val grantHandler: GrantHandler = grantHandlers[grantType] ?: invalidGrant(grantType)
                 val tokenResponse = grantHandler.tokenResponse(it, it.url.toIssuerUrl(), tokenCallback)
                 json(tokenResponse)

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -176,12 +176,11 @@ class OAuth2HttpRequestHandler(
                 log.debug("handle token request $it")
                 val grantType = it.grantType()
                 val issuerId = it.url.issuerId()
-                // For refresh_token grants the handler resolves the callback itself (stored vs enqueued priority).
-                // For all other grants consume from queue or fall back to config default.
+                // For refresh_token grants the handler resolves the callback itself (stored vs enqueued priority),
+                // so the tokenCallback passed here is unused. For all other grants consume from queue or fall back to config default.
                 val tokenCallback: OAuth2TokenCallback =
                     if (grantType == REFRESH_TOKEN) {
-                        config.tokenCallbacks.firstOrNull { cb -> cb.issuerId() == issuerId }
-                            ?: DefaultOAuth2TokenCallback(issuerId = issuerId)
+                        DefaultOAuth2TokenCallback(issuerId = issuerId)
                     } else {
                         tokenCallbackFromQueueOrDefault(issuerId)
                     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RefreshTokenGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RefreshTokenGrantIntegrationTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.asClue
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.shouldNotBe
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.OAuth2Config
@@ -101,6 +102,11 @@ class RefreshTokenGrantIntegrationTest {
         withMockOAuth2Server {
             val expectedSubject = "expectedSub"
             val issuerId = "idprovider"
+
+            val initialResponse = this.runAuthCodeFlow(issuerId, "anysubject")
+            val refreshToken = checkNotNull(initialResponse.refreshToken)
+
+            // enqueue callback after auth code flow so it is consumed by the refresh token request
             this.enqueueCallback(DefaultOAuth2TokenCallback(issuerId = issuerId, subject = expectedSubject))
 
             val refreshTokenResponse =
@@ -109,7 +115,7 @@ class RefreshTokenGrantIntegrationTest {
                         this.tokenEndpointUrl(issuerId),
                         mapOf(
                             "grant_type" to GrantType.REFRESH_TOKEN.value,
-                            "refresh_token" to "canbewhatever",
+                            "refresh_token" to refreshToken,
                             "client_id" to "id",
                             "client_secret" to "secret",
                         ),
@@ -121,24 +127,23 @@ class RefreshTokenGrantIntegrationTest {
     }
 
     @Test
-    fun `token request with refresh_token grant and random refresh token should return random subject in tokens`() {
+    fun `token request with bogus refresh_token should return 400 invalid_grant`() {
         withMockOAuth2Server {
             val issuerId = "idprovider"
-            val refreshTokenResponse =
+            val response =
                 client
                     .tokenRequest(
                         this.tokenEndpointUrl(issuerId),
                         mapOf(
                             "grant_type" to GrantType.REFRESH_TOKEN.value,
-                            "refresh_token" to "canbewhatever",
+                            "refresh_token" to "bogus-random-uuid",
                             "client_id" to "id",
                             "client_secret" to "secret",
                         ),
-                    ).toTokenResponse()
+                    )
 
-            refreshTokenResponse shouldBeValidFor GrantType.REFRESH_TOKEN
-            refreshTokenResponse.idToken!!.subject shouldNotBe null
-            refreshTokenResponse.idToken should verifyWith(issuerId, this)
+            response.code shouldBe 400
+            response.body.string() shouldContain "invalid_grant"
         }
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RefreshTokenGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RefreshTokenGrantIntegrationTest.kt
@@ -147,6 +147,32 @@ class RefreshTokenGrantIntegrationTest {
         }
     }
 
+    @Test
+    fun `refresh_token issued by one issuer should not be accepted by a different issuer`() {
+        withMockOAuth2Server {
+            val issuerA = "issuer-a"
+            val issuerB = "issuer-b"
+
+            val initialResponse = this.runAuthCodeFlow(issuerA, "subject")
+            val refreshToken = checkNotNull(initialResponse.refreshToken)
+
+            val response =
+                client
+                    .tokenRequest(
+                        this.tokenEndpointUrl(issuerB),
+                        mapOf(
+                            "grant_type" to GrantType.REFRESH_TOKEN.value,
+                            "refresh_token" to refreshToken,
+                            "client_id" to "id",
+                            "client_secret" to "secret",
+                        ),
+                    )
+
+            response.code shouldBe 400
+            response.body.string() shouldContain "invalid_grant"
+        }
+    }
+
     private fun MockOAuth2Server.runAuthCodeFlow(
         issuerId: String,
         initialSubject: String,

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RefreshTokenGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RefreshTokenGrantIntegrationTest.kt
@@ -130,20 +130,19 @@ class RefreshTokenGrantIntegrationTest {
     fun `token request with bogus refresh_token should return 400 invalid_grant`() {
         withMockOAuth2Server {
             val issuerId = "idprovider"
-            val response =
-                client
-                    .tokenRequest(
-                        this.tokenEndpointUrl(issuerId),
-                        mapOf(
-                            "grant_type" to GrantType.REFRESH_TOKEN.value,
-                            "refresh_token" to "bogus-random-uuid",
-                            "client_id" to "id",
-                            "client_secret" to "secret",
-                        ),
-                    )
-
-            response.code shouldBe 400
-            response.body.string() shouldContain "invalid_grant"
+            client
+                .tokenRequest(
+                    this.tokenEndpointUrl(issuerId),
+                    mapOf(
+                        "grant_type" to GrantType.REFRESH_TOKEN.value,
+                        "refresh_token" to "bogus-random-uuid",
+                        "client_id" to "id",
+                        "client_secret" to "secret",
+                    ),
+                ).use {
+                    it.code shouldBe 400
+                    it.body.string() shouldContain "invalid_grant"
+                }
         }
     }
 
@@ -156,20 +155,19 @@ class RefreshTokenGrantIntegrationTest {
             val initialResponse = this.runAuthCodeFlow(issuerA, "subject")
             val refreshToken = checkNotNull(initialResponse.refreshToken)
 
-            val response =
-                client
-                    .tokenRequest(
-                        this.tokenEndpointUrl(issuerB),
-                        mapOf(
-                            "grant_type" to GrantType.REFRESH_TOKEN.value,
-                            "refresh_token" to refreshToken,
-                            "client_id" to "id",
-                            "client_secret" to "secret",
-                        ),
-                    )
-
-            response.code shouldBe 400
-            response.body.string() shouldContain "invalid_grant"
+            client
+                .tokenRequest(
+                    this.tokenEndpointUrl(issuerB),
+                    mapOf(
+                        "grant_type" to GrantType.REFRESH_TOKEN.value,
+                        "refresh_token" to refreshToken,
+                        "client_id" to "id",
+                        "client_secret" to "secret",
+                    ),
+                ).use {
+                    it.code shouldBe 400
+                    it.body.string() shouldContain "invalid_grant"
+                }
         }
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RevocationIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RevocationIntegrationTest.kt
@@ -3,6 +3,7 @@ package no.nav.security.mock.oauth2.e2e
 import com.nimbusds.oauth2.sdk.GrantType
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.grant.RefreshToken
 import no.nav.security.mock.oauth2.testutils.ParsedTokenResponse
@@ -42,20 +43,21 @@ class RevocationIntegrationTest {
                         "token_type_hint" to "refresh_token",
                     ),
                 )
-            revocationResponse.code shouldBe 200
+            revocationResponse.use { it.code shouldBe 200 }
 
             // after revocation, using the revoked refresh token must return 400 invalid_grant
-            val postRevocationResponse =
-                client.tokenRequest(
-                    this.tokenEndpointUrl(issuerId),
-                    mapOf(
-                        "grant_type" to GrantType.REFRESH_TOKEN.value,
-                        "refresh_token" to refreshToken,
-                        "client_id" to "id",
-                        "client_secret" to "secret",
-                    ),
-                )
-            postRevocationResponse.code shouldBe 400
+            client.tokenRequest(
+                this.tokenEndpointUrl(issuerId),
+                mapOf(
+                    "grant_type" to GrantType.REFRESH_TOKEN.value,
+                    "refresh_token" to refreshToken,
+                    "client_id" to "id",
+                    "client_secret" to "secret",
+                ),
+            ).use {
+                it.code shouldBe 400
+                it.body.string() shouldContain "invalid_grant"
+            }
         }
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RevocationIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RevocationIntegrationTest.kt
@@ -3,7 +3,6 @@ package no.nav.security.mock.oauth2.e2e
 import com.nimbusds.oauth2.sdk.GrantType
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import no.nav.security.mock.oauth2.MockOAuth2Server
 import no.nav.security.mock.oauth2.grant.RefreshToken
 import no.nav.security.mock.oauth2.testutils.ParsedTokenResponse
@@ -30,7 +29,7 @@ class RevocationIntegrationTest {
             tokenResponseBeforeRefresh.idToken?.subject shouldBe initialSubject
             tokenResponseBeforeRefresh.accessToken?.subject shouldBe initialSubject
 
-            var refreshTokenResponse = refresh(tokenResponseBeforeRefresh.refreshToken)
+            val refreshTokenResponse = refresh(tokenResponseBeforeRefresh.refreshToken)
             refreshTokenResponse.accessToken?.subject shouldBe initialSubject
             val refreshToken = checkNotNull(refreshTokenResponse.refreshToken)
             val revocationResponse =
@@ -45,8 +44,18 @@ class RevocationIntegrationTest {
                 )
             revocationResponse.code shouldBe 200
 
-            refreshTokenResponse = refresh(tokenResponseBeforeRefresh.refreshToken)
-            refreshTokenResponse.accessToken?.subject shouldNotBe initialSubject
+            // after revocation, using the revoked refresh token must return 400 invalid_grant
+            val postRevocationResponse =
+                client.tokenRequest(
+                    this.tokenEndpointUrl(issuerId),
+                    mapOf(
+                        "grant_type" to GrantType.REFRESH_TOKEN.value,
+                        "refresh_token" to refreshToken,
+                        "client_id" to "id",
+                        "client_secret" to "secret",
+                    ),
+                )
+            postRevocationResponse.code shouldBe 400
         }
     }
 


### PR DESCRIPTION
## Problem

Unknown or revoked refresh tokens were silently accepted and issued new tokens using the default callback. This meant any random string passed as a `refresh_token` would return a valid JWT, which would be a security bug in a real authorization server.

Additionally, a refresh token issued under issuer A could be presented to issuer B's token endpoint and be accepted, causing tokens to be minted with issuer B's issuerUrl but issuer A's callback and claims.

The `peek() + take()` pattern used when consuming enqueued callbacks was also non-atomic, meaning two concurrent requests could race between the check and the consume, potentially taking a callback that does not match the issuer just checked.

Finally, the enqueued callback was being polled before the stored callback's issuer was validated. This meant a cross-issuer replay would consume an enqueued callback as a side effect even though the request was going to be rejected.

## Fix

The callback resolution in `RefreshTokenGrantHandler` now follows this order:

1. Look up `storedCallback` from `RefreshTokenManager` and fail fast with `invalid_grant` if its issuer does not match the request issuer, before touching the enqueued callback queue
2. Poll the enqueued callback atomically via `synchronized + poll()` if it matches the issuer
3. Fall back to `storedCallback` if no enqueued callback is present
4. Throw `invalid_grant` if neither is found, covering unknown, expired, and revoked tokens

The same `peek() + take()` race was fixed in `tokenCallbackFromQueueOrDefault` using the same `synchronized + poll()` pattern.

`RefreshTokenManager` now uses `ConcurrentHashMap` instead of `HashMap` for thread safety, consistent with #934.

The `tokenCallback` argument passed into `tokenResponse()` for `REFRESH_TOKEN` grants was dead code since `resolvedCallback` always takes over inside the handler. It is now simplified to a plain `DefaultOAuth2TokenCallback` with a comment explaining it is unused.

## Breaking change (major version bump required: 4.0.0)

Previously any arbitrary string was accepted as a `refresh_token`. Tests relying on this behavior will now receive `400 invalid_grant`. See the migration guide added to `README.md` for details.

**Affected test patterns:**
- Passing a hardcoded or arbitrary string as `refresh_token`
- Expecting refresh to succeed after revocation
- Presenting a refresh token issued by issuer A to issuer B

## Tests

- Enqueued callback test now uses a real refresh token from a completed auth code flow, rather than an arbitrary string
- Bogus refresh token is asserted to return `400` with `invalid_grant` in the response body
- Revoked refresh token is asserted to return `400` with `invalid_grant` in the response body
- Cross-issuer replay is asserted to return `400` with `invalid_grant` in the response body
- Error responses are consumed via `use {}` to avoid leaking OkHttp connections during test runs