### PR TITLE
feat: publish major and minor Docker image tags on release

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -49,3 +49,10 @@ jobs:
           ./gradlew -Pversion=${NEW_VERSION} publishAllPublicationsToGithubPackagesRepository publishAndReleaseToMavenCentral --no-configuration-cache
           # ./gradlew jib --image="${IMAGE}" --image="${IMAGE_DH}"
           ./gradlew jib --image="${IMAGE}"
+          MAJOR=$(echo "${NEW_VERSION}" | cut -d "." -f1)
+          MINOR=$(echo "${NEW_VERSION}" | cut -d "." -f1-2)
+          docker pull "${IMAGE}"
+          docker tag "${IMAGE}" "${IMAGE_NAME}:${MAJOR}"
+          docker tag "${IMAGE}" "${IMAGE_NAME}:${MINOR}"
+          docker push "${IMAGE_NAME}:${MAJOR}"
+          docker push "${IMAGE_NAME}:${MINOR}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -53,5 +53,4 @@ jobs:
           ./gradlew jib --image="${IMAGE}"
           MAJOR=$(echo "${NEW_VERSION}" | cut -d "." -f1)
           MINOR=$(echo "${NEW_VERSION}" | cut -d "." -f1-2)
-          docker buildx imagetools create -t "${IMAGE_NAME}:${MAJOR}" "${IMAGE}"
-          docker buildx imagetools create -t "${IMAGE_NAME}:${MINOR}" "${IMAGE}"
+          docker buildx imagetools create -t "${IMAGE_NAME}:${MAJOR}" -t "${IMAGE_NAME}:${MINOR}" "${IMAGE}"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -26,6 +26,8 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # ratchet:docker/setup-buildx-action@v4.0.0
       #- name: Login to DockerHub
       #  uses: docker/login-action@v3
       #  with:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -51,8 +51,5 @@ jobs:
           ./gradlew jib --image="${IMAGE}"
           MAJOR=$(echo "${NEW_VERSION}" | cut -d "." -f1)
           MINOR=$(echo "${NEW_VERSION}" | cut -d "." -f1-2)
-          docker pull "${IMAGE}"
-          docker tag "${IMAGE}" "${IMAGE_NAME}:${MAJOR}"
-          docker tag "${IMAGE}" "${IMAGE_NAME}:${MINOR}"
-          docker push "${IMAGE_NAME}:${MAJOR}"
-          docker push "${IMAGE_NAME}:${MINOR}"
+          docker buildx imagetools create -t "${IMAGE_NAME}:${MAJOR}" "${IMAGE}"
+          docker buildx imagetools create -t "${IMAGE_NAME}:${MINOR}" "${IMAGE}"

--- a/README.md
+++ b/README.md
@@ -250,6 +250,14 @@ The standalone server defaults to port `8080`.
 docker run -p 8080:8080 ghcr.io/navikt/mock-oauth2-server:$MOCK_OAUTH2_SERVER_VERSION
 ```
 
+Images are also tagged by major and minor version, so you can pin to a release stream:
+
+| Tag | Resolves to |
+|-----|-------------|
+| `ghcr.io/navikt/mock-oauth2-server:3.1.4` | exact version |
+| `ghcr.io/navikt/mock-oauth2-server:3.1` | latest 3.1.x |
+| `ghcr.io/navikt/mock-oauth2-server:3` | latest 3.x.x |
+
 **Build locally:**
 
 ```


### PR DESCRIPTION
Closes #940

After Jib publishes the patch tag (e.g. `3.1.4`), uses `docker buildx imagetools create` to copy the full manifest list registry-to-registry, pushing `3.1` and `3` tags to ghcr.io with multi-arch support (amd64 + arm64) preserved. README updated with a pinning reference table.