### PR TITLE
feat: support interactive login with requestMapping claim selection

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,41 @@
+# Migration guide
+
+## Migrating to 4.0.0
+
+### Refresh token validation is now strict
+
+Previously, any arbitrary string passed as a `refresh_token` was silently accepted and used to mint a new token via the default callback. This has been fixed: unknown, expired, and revoked refresh tokens now fail with `400 invalid_grant`.
+
+**What this means for existing tests:**
+
+- Tests that passed a hardcoded or arbitrary string as `refresh_token` will now receive `400 invalid_grant` instead of a valid token response. Use a real refresh token obtained from a prior token request.
+- Tests that relied on refresh succeeding after revocation will now fail. This is the correct behavior.
+- Tests that presented a refresh token issued by issuer A to issuer B will now receive `400 invalid_grant`.
+
+**Example migration:**
+
+```kotlin
+// Before: arbitrary string was accepted
+val response = client.post(server.tokenEndpointUrl("default")) {
+    body = "grant_type=refresh_token&refresh_token=any-string"
+}
+
+// After: obtain a real refresh token first
+val tokenResponse = client.post(server.tokenEndpointUrl("default")) {
+    body = "grant_type=authorization_code&code=..."
+}
+val refreshToken = tokenResponse.body.refresh_token
+val response = client.post(server.tokenEndpointUrl("default")) {
+    body = "grant_type=refresh_token&refresh_token=$refreshToken"
+}
+```
+
+### Interactive login + `tokenCallbacks`: claim precedence change
+
+In previous versions, claims submitted on the login page could overwrite claims set by a matching `requestMapping` (including `sub`). This could produce tokens where the JWT subject differed from the `sub` claim in the payload.
+
+**New behavior:** claims set by a matching `requestMapping` take priority. Login-page claims can add new claims but cannot overwrite claims already set by the mapping.
+
+**Affected pattern:** using `interactiveLogin: true` together with `tokenCallbacks`, and relying on the login-page `claims` field to override specific claims (e.g. `sub`) that are also set in the matching `requestMapping`.
+
+**Migration:** move the claim into the `requestMapping` instead of submitting it from the login page, or remove the conflicting key from the mapping so the login-page value takes effect.

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ A token request to `http://localhost:8080/issuer1/token` with any `code` paramet
 }
 ```
 
-The `match` field supports exact strings, `"*"` (matches any value), and full regular expressions.
+The `match` field supports exact strings, `"*"` (matches any value), and full regular expressions. If the pattern is an invalid regular expression, it does not throw — regex evaluation is skipped, but exact-string matching still applies.
 
 Use `${clientId}` (or `${client_id}`) in claim values to insert the requesting client ID dynamically. All form parameters from the token request are available as template variables:
 
@@ -390,6 +390,60 @@ Use `${clientId}` (or `${client_id}`) in claim values to insert the requesting c
     ]
 }
 ```
+
+#### Built-in template variables
+
+In addition to form parameters, the following built-in variables are always available:
+
+| Variable | Value |
+|----------|-------|
+| `${clientId}` / `${client_id}` | The `client_id` from the token request |
+
+#### Interactive login: matching and templating on the login username
+
+When `interactiveLogin` is enabled, `requestMappings` can match on the username submitted at the login page using `"requestParam": "subject"`. The login username is also available as `${subject}` in claim values.
+
+This allows a single `JSON_CONFIG` to serve different claim sets per user without a custom login page:
+
+```json
+{
+    "interactiveLogin": true,
+    "tokenCallbacks": [
+        {
+            "issuerId": "default",
+            "requestMappings": [
+                {
+                    "requestParam": "subject",
+                    "match": "alice",
+                    "claims": {
+                        "role": "admin",
+                        "preferred_username": "${subject}"
+                    }
+                },
+                {
+                    "requestParam": "subject",
+                    "match": ".*",
+                    "claims": {
+                        "role": "user",
+                        "preferred_username": "${subject}"
+                    }
+                }
+            ]
+        }
+    ]
+}
+```
+
+**Claim precedence** when combining `requestMappings` with interactive login:
+
+1. Claims set by a matching `requestMapping` take priority.
+2. Claims submitted on the login page can add new claims but cannot overwrite claims already set by the mapping.
+
+**Template variable precedence** (highest wins):
+
+1. `client_id` / `clientId` — always authoritative
+2. Token POST body form parameters
+3. `${subject}` and other built-in variables
 
 ### Auto-added claims
 
@@ -628,32 +682,4 @@ This library is licensed under the [MIT License](LICENSE.md).
 
 ## Migration guide
 
-### Migrating to 4.0.0
-
-#### Refresh token validation is now strict
-
-Previously, any arbitrary string passed as a `refresh_token` was silently accepted and used to mint a new token via the default callback. This has been fixed: unknown, expired, and revoked refresh tokens now fail with `400 invalid_grant`.
-
-**What this means for existing tests:**
-
-- Tests that passed a hardcoded or arbitrary string as `refresh_token` will now receive `400 invalid_grant` instead of a valid token response. Use a real refresh token obtained from a prior token request.
-- Tests that relied on refresh succeeding after revocation will now fail. This is the correct behavior.
-- Tests that presented a refresh token issued by issuer A to issuer B will now receive `400 invalid_grant`.
-
-**Example migration:**
-
-```kotlin
-// Before: arbitrary string was accepted
-val response = client.post(server.tokenEndpointUrl("default")) {
-    body = "grant_type=refresh_token&refresh_token=any-string"
-}
-
-// After: obtain a real refresh token first
-val tokenResponse = client.post(server.tokenEndpointUrl("default")) {
-    body = "grant_type=authorization_code&code=..."
-}
-val refreshToken = tokenResponse.body.refresh_token
-val response = client.post(server.tokenEndpointUrl("default")) {
-    body = "grant_type=refresh_token&refresh_token=$refreshToken"
-}
-```
+See [MIGRATION.md](MIGRATION.md) for upgrade instructions between versions.

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -20,6 +20,7 @@ import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
 import no.nav.security.mock.oauth2.login.Login
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
+import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
 import okhttp3.HttpUrl
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
@@ -121,23 +122,38 @@ internal class AuthorizationCodeHandler(
         val login: Login,
         val oAuth2TokenCallback: OAuth2TokenCallback,
     ) : OAuth2TokenCallback {
-        override fun issuerId(): String = oAuth2TokenCallback.issuerId()
+        private val resolvedDelegate: OAuth2TokenCallback =
+            when (oAuth2TokenCallback) {
+                is RequestMappingTokenCallback ->
+                    oAuth2TokenCallback.withExtraMatchParams(mapOf(RequestMappingTokenCallback.SUBJECT_PARAM to login.username))
+                else -> oAuth2TokenCallback
+            }
 
-        override fun subject(tokenRequest: TokenRequest): String = login.username
+        private val subjectResolver: (TokenRequest) -> String =
+            when (oAuth2TokenCallback) {
+                is RequestMappingTokenCallback -> { req -> resolvedDelegate.subject(req) ?: login.username }
+                else -> { _ -> login.username }
+            }
 
-        override fun typeHeader(tokenRequest: TokenRequest): String = oAuth2TokenCallback.typeHeader(tokenRequest)
+        override fun issuerId(): String = resolvedDelegate.issuerId()
 
-        override fun audience(tokenRequest: TokenRequest): List<String> = oAuth2TokenCallback.audience(tokenRequest)
+        override fun subject(tokenRequest: TokenRequest): String = subjectResolver(tokenRequest)
+
+        override fun typeHeader(tokenRequest: TokenRequest): String = resolvedDelegate.typeHeader(tokenRequest)
+
+        override fun audience(tokenRequest: TokenRequest): List<String> = resolvedDelegate.audience(tokenRequest)
 
         override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
-            oAuth2TokenCallback.addClaims(tokenRequest).toMutableMap().apply {
+            resolvedDelegate.addClaims(tokenRequest).toMutableMap().apply {
+                // Claim precedence: mapping/callback claims win over login-page claims.
+                // login.claims can add new claims but cannot overwrite claims already set by the mapping.
                 login.claims?.let {
                     try {
                         jsonMapper
                             .readTree(it)
                             .properties()
                             .forEach { field ->
-                                put(field.key, jsonMapper.readValue(field.value.toString()))
+                                putIfAbsent(field.key, jsonMapper.readValue(field.value.toString()))
                             }
                     } catch (exception: JsonProcessingException) {
                         log.warn("claims value $it could not be processed as JSON, details: ${exception.message}")
@@ -145,6 +161,6 @@ internal class AuthorizationCodeHandler(
                 }
             }
 
-        override fun tokenExpiry(): Long = oAuth2TokenCallback.tokenExpiry()
+        override fun tokenExpiry(): Long = resolvedDelegate.tokenExpiry()
     }
 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallback.kt
@@ -3,6 +3,7 @@ package no.nav.security.mock.oauth2.token
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.oauth2.sdk.GrantType
 import com.nimbusds.oauth2.sdk.TokenRequest
+import mu.KotlinLogging
 import no.nav.security.mock.oauth2.extensions.clientIdAsString
 import no.nav.security.mock.oauth2.extensions.grantType
 import no.nav.security.mock.oauth2.extensions.replaceValues
@@ -10,6 +11,8 @@ import no.nav.security.mock.oauth2.extensions.scopesWithoutOidcScopes
 import no.nav.security.mock.oauth2.grant.audienceOrEmpty
 import java.time.Duration
 import java.util.UUID
+
+private val log = KotlinLogging.logger {}
 
 interface OAuth2TokenCallback {
     fun issuerId(): String
@@ -75,36 +78,85 @@ data class RequestMappingTokenCallback(
     val requestMappings: List<RequestMapping>,
     val tokenExpiry: Long = Duration.ofHours(1).toSeconds(),
 ) : OAuth2TokenCallback {
+    companion object {
+        const val SUBJECT_PARAM = "subject"
+    }
     override fun issuerId(): String = issuerId
 
-    override fun subject(tokenRequest: TokenRequest): String? = requestMappings.getClaimOrNull(tokenRequest, "sub")
+    override fun subject(tokenRequest: TokenRequest): String? = resolve(tokenRequest).claims["sub"] as? String
 
-    override fun typeHeader(tokenRequest: TokenRequest): String = requestMappings.getTypeHeader(tokenRequest)
+    override fun typeHeader(tokenRequest: TokenRequest): String = resolve(tokenRequest).typeHeader
 
-    override fun audience(tokenRequest: TokenRequest): List<String> = requestMappings.getClaimOrNull(tokenRequest, "aud") ?: emptyList()
+    override fun audience(tokenRequest: TokenRequest): List<String> =
+        resolve(tokenRequest).claims["aud"].toAudienceList()
 
-    override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> = requestMappings.getClaims(tokenRequest)
+    override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> = resolve(tokenRequest).claims
 
     override fun tokenExpiry(): Long = tokenExpiry
 
-    private fun List<RequestMapping>.getClaims(tokenRequest: TokenRequest): Map<String, Any> {
-        val claims = firstOrNull { it.isMatch(tokenRequest) }?.claims ?: emptyMap()
-        val templateParams = tokenRequest.toHTTPRequest().bodyAsFormParameters.mapValues { it.value.joinToString(separator = " ") }
+    /**
+     * Returns a view of this callback that supplements matching with [extraMatchParams] —
+     * key/value pairs that are considered when no matching form parameter is found in the token request body.
+     *
+     * Intended for use during interactive login, where the login username is injected under the
+     * [SUBJECT_PARAM] key so that a [RequestMapping] with `requestParam = "subject"` can match on it:
+     *
+     * ```json
+     * { "requestParam": "subject", "match": "alice", "claims": { "role": "admin" } }
+     * ```
+     *
+     * **Precedence (highest to lowest):**
+     * 1. `client_id` / `clientId` — always authoritative
+     * 2. Token request form parameters — override extra params on the same key
+     * 3. [extraMatchParams] — used only when no form parameter exists for the key
+     */
+    fun withExtraMatchParams(extraMatchParams: Map<String, String>): OAuth2TokenCallback =
+        ExtraMatchParamsWrapper(extraMatchParams)
 
-        // in case client_id is not set as form param but as basic auth, we add it to the template params in two different formats for backwards compatibility
-        return claims.replaceValues(
-            templateParams +
-                mapOf("clientId" to tokenRequest.clientIdAsString()) +
-                mapOf("client_id" to tokenRequest.clientIdAsString()),
+    private inner class ExtraMatchParamsWrapper(
+        private val extraMatchParams: Map<String, String>,
+    ) : OAuth2TokenCallback by this@RequestMappingTokenCallback {
+        override fun subject(tokenRequest: TokenRequest): String? =
+            resolve(tokenRequest, extraMatchParams).claims["sub"] as? String
+
+        override fun typeHeader(tokenRequest: TokenRequest): String =
+            resolve(tokenRequest, extraMatchParams).typeHeader
+
+        override fun audience(tokenRequest: TokenRequest): List<String> =
+            resolve(tokenRequest, extraMatchParams).claims["aud"].toAudienceList()
+
+        override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> =
+            resolve(tokenRequest, extraMatchParams).claims
+    }
+
+    private fun resolve(
+        tokenRequest: TokenRequest,
+        extraMatchParams: Map<String, String> = emptyMap(),
+    ): ResolvedMapping {
+        val rawFormParams: Map<String, List<String>> = tokenRequest.toHTTPRequest().bodyAsFormParameters
+        val matched = requestMappings.firstOrNull { it.isMatch(rawFormParams, tokenRequest, extraMatchParams) }
+        val rawClaims = matched?.claims ?: emptyMap()
+        // Template variable precedence (highest to lowest):
+        //   1. client_id / clientId  — always authoritative
+        //   2. form params           — token POST body
+        //   3. extraMatchParams      — e.g. login subject
+        val templateParams =
+            buildMap {
+                putAll(extraMatchParams)
+                putAll(rawFormParams.mapValues { it.value.joinToString(separator = " ") })
+                put("clientId", tokenRequest.clientIdAsString())
+                put("client_id", tokenRequest.clientIdAsString())
+            }
+        return ResolvedMapping(
+            claims = rawClaims.replaceValues(templateParams),
+            typeHeader = matched?.typeHeader ?: JOSEObjectType.JWT.type,
         )
     }
 
-    private inline fun <reified T> List<RequestMapping>.getClaimOrNull(
-        tokenRequest: TokenRequest,
-        key: String,
-    ): T? = getClaims(tokenRequest)[key] as? T
-
-    private fun List<RequestMapping>.getTypeHeader(tokenRequest: TokenRequest) = firstOrNull { it.isMatch(tokenRequest) }?.typeHeader ?: JOSEObjectType.JWT.type
+    private data class ResolvedMapping(
+        val claims: Map<String, Any>,
+        val typeHeader: String,
+    )
 }
 
 data class RequestMapping(
@@ -113,20 +165,48 @@ data class RequestMapping(
     val claims: Map<String, Any> = emptyMap(),
     val typeHeader: String = JOSEObjectType.JWT.type,
 ) {
-    fun isMatch(tokenRequest: TokenRequest): Boolean {
-        val formValues = tokenRequest.toHTTPRequest().bodyAsFormParameters[requestParam]
+    private val matchRegex: Regex? =
+        if (match == "*") {
+            null
+        } else {
+            runCatching { match.toRegex() }.getOrElse {
+                log.warn("RequestMapping match value '{}' is not a valid regex — only exact-string matching will apply", match)
+                null
+            }
+        }
+
+    fun isMatch(
+        formParams: Map<String, List<String>>,
+        tokenRequest: TokenRequest,
+        extraMatchParams: Map<String, String> = emptyMap(),
+    ): Boolean {
         val effectiveValues =
-            if (formValues == null && requestParam == "client_id") {
-                tokenRequest.clientAuthentication
-                    ?.clientID
-                    ?.value
-                    ?.let { listOf(it) }
-                    ?: tokenRequest.clientID?.value?.let { listOf(it) }
-            } else {
-                formValues
+            when {
+                formParams[requestParam].isNullOrEmpty().not() -> formParams[requestParam]
+                requestParam == "client_id" ->
+                    tokenRequest.clientAuthentication?.clientID?.value?.let { listOf(it) }
+                        ?: tokenRequest.clientID?.value?.let { listOf(it) }
+                else -> extraMatchParams[requestParam]?.let { listOf(it) }
             }
         return effectiveValues?.any {
-            match == "*" || match == it || match.toRegex().matchEntire(it) != null
+            match == "*" || match == it || matchRegex?.matchEntire(it) != null
         } ?: false
     }
+
+    fun isMatch(
+        tokenRequest: TokenRequest,
+        extraMatchParams: Map<String, String> = emptyMap(),
+    ): Boolean =
+        isMatch(
+            tokenRequest.toHTTPRequest().bodyAsFormParameters,
+            tokenRequest,
+            extraMatchParams,
+        )
 }
+
+private fun Any?.toAudienceList(): List<String> =
+    when (this) {
+        is String -> listOf(this)
+        is List<*> -> filterIsInstance<String>()
+        else -> emptyList()
+    }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/InteractiveLoginIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/InteractiveLoginIntegrationTest.kt
@@ -16,7 +16,10 @@ import no.nav.security.mock.oauth2.testutils.post
 import no.nav.security.mock.oauth2.testutils.subject
 import no.nav.security.mock.oauth2.testutils.toTokenResponse
 import no.nav.security.mock.oauth2.testutils.tokenRequest
+import no.nav.security.mock.oauth2.token.RequestMapping
+import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -31,12 +34,122 @@ class InteractiveLoginIntegrationTest {
     @MethodSource("testUsers")
     internal fun `interactive login with a supplied username should result in id_token containing sub and claims from input`(user: User) {
         val code = loginForCode(user)
-
-        val response = tokenRequest(code)
-
+        val response = fetchToken(code)
         response.idToken.shouldNotBeNull()
         response.idToken.subject shouldBe user.username
         response.idToken.claims shouldContainAll user.claims
+    }
+
+    @Test
+    fun `interactive login selects requestMapping based on login username as subject`() {
+        val requestMappingCallback =
+            RequestMappingTokenCallback(
+                issuerId = issuerId,
+                requestMappings =
+                    listOf(
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "alice",
+                            claims = mapOf("role" to "admin", "sub" to "alice"),
+                        ),
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "bob",
+                            claims = mapOf("role" to "user", "sub" to "bob"),
+                        ),
+                    ),
+            )
+        MockOAuth2Server(
+            OAuth2Config(
+                interactiveLogin = true,
+                tokenCallbacks = setOf(requestMappingCallback),
+            ),
+        ).apply { start() }.let { srv ->
+            try {
+                val aliceCode = loginForCode(User(username = "alice"), srv)
+                val bobCode = loginForCode(User(username = "bob"), srv)
+
+                val aliceResponse = fetchToken(aliceCode, srv)
+                val bobResponse = fetchToken(bobCode, srv)
+
+                aliceResponse.idToken.shouldNotBeNull()
+                aliceResponse.idToken.subject shouldBe "alice"
+                aliceResponse.idToken.claims shouldContainAll mapOf("role" to "admin")
+                aliceResponse.idToken.claims["sub"] shouldBe "alice"
+
+                bobResponse.idToken.shouldNotBeNull()
+                bobResponse.idToken.subject shouldBe "bob"
+                bobResponse.idToken.claims shouldContainAll mapOf("role" to "user")
+                bobResponse.idToken.claims["sub"] shouldBe "bob"
+            } finally {
+                srv.shutdown()
+            }
+        }
+    }
+
+    @Test
+    fun `mapping sub claim is not overwritten by login claims`() {
+        val requestMappingCallback =
+            RequestMappingTokenCallback(
+                issuerId = issuerId,
+                requestMappings =
+                    listOf(
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "alice",
+                            claims = mapOf("sub" to "mapped-alice"),
+                        ),
+                    ),
+            )
+        MockOAuth2Server(
+            OAuth2Config(
+                interactiveLogin = true,
+                tokenCallbacks = setOf(requestMappingCallback),
+            ),
+        ).apply { start() }.let { srv ->
+            try {
+                val code = loginForCode(User(username = "alice", claims = mapOf("sub" to "login-alice")), srv)
+                val response = fetchToken(code, srv)
+                response.idToken.shouldNotBeNull()
+                response.idToken.subject shouldBe "mapped-alice"
+                response.idToken.claims["sub"] shouldBe "mapped-alice"
+            } finally {
+                srv.shutdown()
+            }
+        }
+    }
+
+    @Test
+    fun `interactive login subject falls back to login username when matching mapping omits sub`() {
+        val requestMappingCallback =
+            RequestMappingTokenCallback(
+                issuerId = issuerId,
+                requestMappings =
+                    listOf(
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "alice",
+                            claims = mapOf("role" to "admin"),
+                        ),
+                    ),
+            )
+        MockOAuth2Server(
+            OAuth2Config(
+                interactiveLogin = true,
+                tokenCallbacks = setOf(requestMappingCallback),
+            ),
+        ).apply { start() }.let { srv ->
+            try {
+                val code = loginForCode(User(username = "alice"), srv)
+                val response = fetchToken(code, srv)
+                response.idToken.shouldNotBeNull()
+                response.idToken.subject shouldBe "alice"
+                response.idToken.claims["sub"] shouldBe "alice"
+                response.idToken.claims["role"] shouldBe "admin"
+            } finally {
+                srv.shutdown()
+            }
+        }
     }
 
     companion object {
@@ -46,31 +159,27 @@ class InteractiveLoginIntegrationTest {
                 Arguments.of(
                     User(
                         username = "user1",
-                        claims =
-                            mapOf(
-                                "claim1" to "claim1value",
-                            ),
+                        claims = mapOf("claim1" to "claim1value"),
                     ),
                 ),
                 Arguments.of(
                     User(
                         username = "user2",
-                        claims =
-                            mapOf(
-                                "claim2" to "claim2value",
-                            ),
+                        claims = mapOf("claim2" to "claim2value"),
                     ),
                 ),
             )
     }
 
-    private fun loginForCode(user: User): String {
-        val loginUrl = server.authorizationEndpointUrl(issuerId).authenticationRequest()
+    private fun loginForCode(
+        user: User,
+        srv: MockOAuth2Server = server,
+    ): String {
+        val loginUrl = srv.authorizationEndpointUrl(issuerId).authenticationRequest()
         client.get(loginUrl).asClue {
             it.code shouldBe 200
             it.body.string() shouldContain "<html"
         }
-
         return client
             .post(
                 loginUrl,
@@ -84,18 +193,20 @@ class InteractiveLoginIntegrationTest {
             }
     }
 
-    private fun tokenRequest(authCode: String) =
-        client
-            .tokenRequest(
-                server.tokenEndpointUrl(issuerId),
-                mapOf(
-                    "client_id" to "client1",
-                    "client_secret" to "secret",
-                    "grant_type" to "authorization_code",
-                    "redirect_uri" to "http://mycallback",
-                    "code" to authCode,
-                ),
-            ).toTokenResponse()
+    private fun fetchToken(
+        authCode: String,
+        srv: MockOAuth2Server = server,
+    ) = client
+        .tokenRequest(
+            srv.tokenEndpointUrl(issuerId),
+            mapOf(
+                "client_id" to "client1",
+                "client_secret" to "secret",
+                "grant_type" to "authorization_code",
+                "redirect_uri" to "http://mycallback",
+                "code" to authCode,
+            ),
+        ).toTokenResponse()
 
     internal data class User(
         val username: String,

--- a/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/token/OAuth2TokenCallbackTest.kt
@@ -155,6 +155,24 @@ internal class OAuth2TokenCallbackTest {
         }
 
         @Test
+        fun `invalid regex in match skips regex evaluation without throwing, exact-string matching still applies`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "scope",
+                                match = "[invalid(regex",
+                                claims = mapOf("sub" to "shouldNotMatch"),
+                            ),
+                        ),
+                )
+            callback.addClaims(clientCredentialsRequest("scope" to "anything")) shouldBe emptyMap()
+            callback.addClaims(clientCredentialsRequest("scope" to "[invalid(regex")) shouldContainAll mapOf("sub" to "shouldNotMatch")
+        }
+
+        @Test
         fun `token request with request params matching requestmapping should return specific claims from callback with audience`() {
             val grantTypeShouldMatch = clientCredentialsRequest("audience" to "https://myapp.com/jwt/aud/xxx")
             assertSoftly {
@@ -190,6 +208,68 @@ internal class OAuth2TokenCallbackTest {
             ).addClaims(request).asClue {
                 it shouldContainAll mapOf("sub" to clientId, "scope" to "testscope:something another:scope", "mock_token_type" to "custom")
             }
+        }
+
+        @Test
+        fun `token request with aud set as a single string should return it wrapped in a list`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "grant_type",
+                                match = "authorization_code",
+                                claims = mapOf("aud" to "my-api"),
+                            ),
+                        ),
+                )
+            callback.audience(authCodeRequest()) shouldBe listOf("my-api")
+        }
+
+        @Test
+        fun `repeated form param values are matched individually, not as a joined string`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "resource",
+                                match = "api://app-b",
+                                claims = mapOf("sub" to "matchedByResourceB"),
+                            ),
+                        ),
+                )
+            val requestWithRepeatedResource = nimbusTokenRequest(
+                clientId,
+                "grant_type" to "client_credentials",
+                "resource" to "api://app-a",
+                "resource" to "api://app-b",
+            )
+            // Verify both values are preserved in the underlying HTTP request body —
+            // nimbusTokenRequest joins pairs via joinToString("&"), so duplicates are not collapsed.
+            val bodyParams = requestWithRepeatedResource.toHTTPRequest().bodyAsFormParameters
+            bodyParams["resource"] shouldBe listOf("api://app-a", "api://app-b")
+
+            callback.subject(requestWithRepeatedResource) shouldBe "matchedByResourceB"
+        }
+
+        @Test
+        fun `token request with aud set as a list should return it as-is`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "grant_type",
+                                match = "authorization_code",
+                                claims = mapOf("aud" to listOf("my-api", "other-api")),
+                            ),
+                        ),
+                )
+            callback.audience(authCodeRequest()) shouldBe listOf("my-api", "other-api")
         }
     }
 
@@ -230,6 +310,284 @@ internal class OAuth2TokenCallbackTest {
                             "readAs" to listOf("readAs"),
                         ),
                 )
+        }
+    }
+
+    @Nested
+    inner class WithExtraMatchParams {
+        private val callback =
+            RequestMappingTokenCallback(
+                issuerId = "issuer1",
+                requestMappings =
+                    listOf(
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "alice",
+                            claims = mapOf("role" to "admin", "sub" to "alice"),
+                        ),
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "bob",
+                            claims = mapOf("role" to "user", "sub" to "bob"),
+                        ),
+                        RequestMapping(
+                            requestParam = "subject",
+                            match = "*",
+                            claims = mapOf("role" to "guest", "sub" to "unknown"),
+                        ),
+                    ),
+            )
+
+        @Test
+        fun `withExtraMatchParams matches via regex when value comes from extraMatchParams`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "admin-.*",
+                                claims = mapOf("role" to "admin"),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            callback.withExtraMatchParams(mapOf("subject" to "admin-alice")).addClaims(tokenRequest) shouldContainAll mapOf("role" to "admin")
+            callback.withExtraMatchParams(mapOf("subject" to "user-alice")).addClaims(tokenRequest) shouldBe emptyMap()
+        }
+
+        @Test
+        fun `withExtraMatchParams selects correct requestMapping based on subject`() {
+            val tokenRequest = authCodeRequest()
+            val aliceCallback = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            val bobCallback = callback.withExtraMatchParams(mapOf("subject" to "bob"))
+            assertSoftly {
+                aliceCallback.addClaims(tokenRequest) shouldContainAll mapOf("role" to "admin")
+                aliceCallback.subject(tokenRequest) shouldBe "alice"
+                bobCallback.addClaims(tokenRequest) shouldContainAll mapOf("role" to "user")
+                bobCallback.subject(tokenRequest) shouldBe "bob"
+            }
+        }
+
+        @Test
+        fun `withExtraMatchParams falls back to wildcard when subject does not match any specific mapping`() {
+            val tokenRequest = authCodeRequest()
+            val unknownCallback = callback.withExtraMatchParams(mapOf("subject" to "charlie"))
+            assertSoftly {
+                unknownCallback.addClaims(tokenRequest) shouldContainAll mapOf("role" to "guest")
+            }
+        }
+
+        @Test
+        fun `form param takes precedence over extraMatchParams on same key`() {
+            val callbackWithGrantType =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "grant_type",
+                                match = "authorization_code",
+                                claims = mapOf("role" to "fromForm"),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callbackWithGrantType.withExtraMatchParams(mapOf("grant_type" to "something_else"))
+            wrapped.addClaims(tokenRequest) shouldContainAll mapOf("role" to "fromForm")
+        }
+
+        @Test
+        fun `extraMatchParams are available as template variables in claim values`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("preferred_username" to "\${subject}", "role" to "admin"),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.addClaims(tokenRequest) shouldContainAll mapOf("preferred_username" to "alice", "role" to "admin")
+        }
+
+        @Test
+        fun `form params take precedence over extraMatchParams as template variables`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "*",
+                                claims = mapOf("resolved" to "\${grant_type}"),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice", "grant_type" to "should_be_overridden"))
+            wrapped.addClaims(tokenRequest) shouldContainAll mapOf("resolved" to "authorization_code")
+        }
+
+
+        @Test
+        fun `subject is null when mapping does not set sub`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("role" to "admin"),
+                            ),
+                        ),
+                )
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.subject(authCodeRequest()) shouldBe null
+        }
+
+        @Test
+        fun `subject comes from mapping when sub is set`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("sub" to "mapped-alice", "role" to "admin"),
+                            ),
+                        ),
+                )
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.subject(authCodeRequest()) shouldBe "mapped-alice"
+        }
+
+
+        @Test
+        fun `withExtraMatchParams selects typeHeader from matched mapping`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("sub" to "alice"),
+                                typeHeader = "at+JWT",
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.typeHeader(tokenRequest) shouldBe "at+JWT"
+        }
+
+        @Test
+        fun `withExtraMatchParams selects audience from matched mapping`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("sub" to "alice", "aud" to listOf("my-api")),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.audience(tokenRequest) shouldBe listOf("my-api")
+        }
+
+
+        @Test
+        fun `withExtraMatchParams selects audience from matched mapping when aud is a string`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("sub" to "alice", "aud" to "my-api"),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.audience(tokenRequest) shouldBe listOf("my-api")
+        }
+
+        @Test
+        fun `withExtraMatchParams selects audience from matched mapping when aud is a list`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("sub" to "alice", "aud" to listOf("my-api", "other-api")),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "alice"))
+            wrapped.audience(tokenRequest) shouldBe listOf("my-api", "other-api")
+        }
+
+        @Test
+        fun `withExtraMatchParams returns empty audience when no mapping matches`() {
+            val callback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("aud" to listOf("my-api")),
+                            ),
+                        ),
+                )
+            val wrapped = callback.withExtraMatchParams(mapOf("subject" to "bob"))
+            wrapped.audience(authCodeRequest()) shouldBe emptyList()
+        }
+
+
+        @Test
+        fun `withExtraMatchParams returns no match when no mapping matches and no wildcard`() {
+            val strictCallback =
+                RequestMappingTokenCallback(
+                    issuerId = "issuer1",
+                    requestMappings =
+                        listOf(
+                            RequestMapping(
+                                requestParam = "subject",
+                                match = "alice",
+                                claims = mapOf("role" to "admin"),
+                            ),
+                        ),
+                )
+            val tokenRequest = authCodeRequest()
+            val wrapped = strictCallback.withExtraMatchParams(mapOf("subject" to "bob"))
+            wrapped.addClaims(tokenRequest) shouldBe emptyMap()
         }
     }
 


### PR DESCRIPTION
Closes #942

When `interactiveLogin` is enabled, `requestMappings` can now match on the login username via `"requestParam": "subject"`. The username is also available as `${subject}` in claim values, allowing per-user claim sets from a single JSON config without a custom login page.

Claims set by a matching mapping take priority over login-page claims.

Also addresses the use case from #404 (closed as stale) — matching `requestMappings` on the logged-in username to return different claims per user now works via `"requestParam": "subject"`.

---

### Breaking change

Previously, claims submitted on the interactive login page would overwrite claims set by a matching `requestMapping`. The order is now reversed: mapping claims take priority and login-page claims can only add new claims, not overwrite existing ones.

**Before:** login-page claims win on key collision.
**After:** mapping claims win on key collision.

If you relied on the login page to override mapping claims, move those overrides into the `requestMapping` itself.