### PR TITLE
fix: force netty-transport-native-epoll to 4.2.13.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -144,7 +144,10 @@ dependencies {
 
 configurations {
     all {
-        resolutionStrategy.force("com.fasterxml.woodstox:woodstox-core:7.1.1")
+        resolutionStrategy.force(
+            "com.fasterxml.woodstox:woodstox-core:7.1.1",
+            "io.netty:netty-transport-native-epoll:$nettyVersion",
+        )
     }
 }
 


### PR DESCRIPTION
Resolves https://github.com/navikt/mock-oauth2-server/security/dependabot/97

Both `org.springframework.boot:spring-boot-starter-webflux` and `io.ktor:ktor-server-netty` introduce `io.netty:netty-transport-native-epoll` as a transitive dependency at versions below `4.2.13.Final`. Forces the resolution to `4.2.13.Final` via `resolutionStrategy.force`, consistent with how other transitive dependency versions are managed in this project.