### PR TITLE
chore: add security findings label to release-drafter

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -17,6 +17,9 @@ categories:
   - title: '🧰 Maintenance'
     labels:
       - 'chore'
+  - title: '🔒 Security'
+    labels:
+      - 'security findings'
   - title: '⬆️ Dependency upgrades'
     labels:
       - 'bump'


### PR DESCRIPTION
Adds a 🔒 Security category to release-drafter so PRs labelled with `security findings` are grouped correctly in the release notes.