### PR TITLE
build: align kotlin plugins to 2.4.0 without breaking consumer target

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,7 @@ plugins {
     id("com.google.cloud.tools.jib") version "3.5.3"
     id("com.vanniktech.maven.publish") version "0.36.0"
     id("org.jetbrains.dokka") version "2.2.0"
-    kotlin("plugin.serialization") version "2.3.21"
+    alias(libs.plugins.kotlin.serialization)
     `java-library`
     signing
 }
@@ -45,13 +45,14 @@ java {
 
 kotlin {
     val kotlinTarget = libs.versions.kotlinTarget
-    val kotlinTargetVersion = kotlinTarget.map {
+    val kotlinLanguage = libs.versions.kotlinLanguage
+    val kotlinLanguageVersion = kotlinLanguage.map {
         KotlinVersion.fromVersion(it.toKotlinMinor())
     }
 
     compilerOptions {
-        languageVersion = kotlinTargetVersion
-        apiVersion = kotlinTargetVersion
+        languageVersion = kotlinLanguageVersion
+        apiVersion = kotlinLanguageVersion
         // Syncing Kotlin JVM target with Java plugin JVM target
         jvmTarget = JvmTarget.JVM_17
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,8 @@
 [versions]
 kotlinTarget = "1.9.0" # Minimum supported Kotlin version for consumers of the library
-kotlinToolchain = "2.3.21" # Actual version used by tooling within this project
+kotlinLanguage = "2.0" # Language level used by compiler (Kotlin 2.4 no longer supports 1.9 language mode)
+kotlinToolchain = "2.4.0" # Actual version used by tooling within this project
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinToolchain" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinToolchain" }


### PR DESCRIPTION
Supersedes #956.

- Aligns `kotlin-jvm` and `kotlin-serialization` plugin versions on 2.4.0.
- Keeps `kotlinTarget` at 1.9.0 to avoid raising consumer requirements.
- Uses Kotlin language/api level 2.0 for this project build (required by Kotlin 2.4 tooling).