### PR TITLE
docs: add migration guidance for 5.0.0 claim precedence change 

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,17 @@
 # Migration guide
 
+## Migrating to 5.0.0
+
+### Interactive login + `requestMappings`: claim precedence change
+
+In previous versions, claims submitted on the login page could overwrite claims set by a matching `requestMapping` (including `sub`). This could produce tokens where the JWT subject differed from the `sub` claim in the payload.
+
+**New behavior (5.0.0):** claims set by a matching `requestMapping` take priority. Login-page claims can add new claims but cannot overwrite claims already set by the mapping.
+
+**Affected pattern:** using `interactiveLogin: true` together with mappings/token callbacks, and relying on the login-page `claims` field to override specific claims (for example `sub`) that are also set in the matching `requestMapping`.
+
+**Migration:** move the overriding claim into `requestMappings`, or remove the conflicting key from the mapping if you want the login-page claim to be used.
+
 ## Migrating to 4.0.0
 
 ### Refresh token validation is now strict
@@ -29,13 +41,3 @@ val response = client.post(server.tokenEndpointUrl("default")) {
     body = "grant_type=refresh_token&refresh_token=$refreshToken"
 }
 ```
-
-### Interactive login + `tokenCallbacks`: claim precedence change
-
-In previous versions, claims submitted on the login page could overwrite claims set by a matching `requestMapping` (including `sub`). This could produce tokens where the JWT subject differed from the `sub` claim in the payload.
-
-**New behavior:** claims set by a matching `requestMapping` take priority. Login-page claims can add new claims but cannot overwrite claims already set by the mapping.
-
-**Affected pattern:** using `interactiveLogin: true` together with `tokenCallbacks`, and relying on the login-page `claims` field to override specific claims (e.g. `sub`) that are also set in the matching `requestMapping`.
-
-**Migration:** move the claim into the `requestMapping` instead of submitting it from the login page, or remove the conflicting key from the mapping so the login-page value takes effect.


### PR DESCRIPTION
Adds 5.0.0 migration guidance for interactive login claim precedence with `requestMappings`.                                                                                                                                                                                                                                                
- mapping claims now win on key collisions                                                                                                                                                                  
- login-page claims only add missing keys                                                                                                                                                                   
- moved this note from 4.0.0 section to 5.0.0 