### PR TITLE
ci: migrate release-drafter config away from deprecated fields

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -3,29 +3,37 @@ tag-template: $NEXT_PATCH_VERSION
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 categories:
   - title: '🚀 Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
+    when:
+      labels:
+        - 'feature'
+        - 'enhancement'
   - title: '⚠️ Breaking Changes'
-    labels:
-      - 'breaking'
+    when:
+      labels:
+        - 'breaking'
   - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
+    when:
+      labels:
+        - 'fix'
+        - 'bugfix'
+        - 'bug'
   - title: '🧰 Maintenance'
-    labels:
-      - 'chore'
+    when:
+      labels:
+        - 'chore'
   - title: '🔒 Security'
-    labels:
-      - 'security findings'
+    when:
+      labels:
+        - 'security findings'
   - title: '⬆️ Dependency upgrades'
-    labels:
-      - 'bump'
-      - 'dependencies'
-exclude-labels:
-  - 'skip-changelog'
+    when:
+      labels:
+        - 'bump'
+        - 'dependencies'
+  - type: 'pre-exclude'
+    when:
+      labels:
+        - 'skip-changelog'
 template: |
   ## What's Changed
   $CHANGES


### PR DESCRIPTION
Migrates `.github/release-drafter.yml` to the new config syntax.

- `categories[*].labels` -> `categories[*].when.labels`
- `exclude-labels` -> `type: "pre-exclude"` category

No intended behavior change, only deprecation cleanup.