### PR TITLE
ci: harden release version resolution in publish workflows

### DIFF
--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -24,8 +24,17 @@ jobs:
           distribution: 'temurin'
           cache: 'gradle'
 
-      - name: Get the tag name
-        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_ENV
+      - name: Get the release version
+        # Use release event payload as source of truth for version.
+        # For `release: published`, `github.event.release.tag_name` contains the release tag.
+        # Fail fast if empty to avoid running Dokka with an empty version.
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          if [ -z "${VERSION}" ]; then
+            echo "VERSION is empty (github.event.release.tag_name missing). Failing early."
+            exit 1
+          fi
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
 
       - name: Build Dokka
         run: ./gradlew dokkaGenerateHtml -Pversion=${{ env.VERSION }}

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -38,10 +38,10 @@ jobs:
             echo "VERSION is empty (github.event.release.tag_name missing). Failing early."
             exit 1
           fi
-          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          printf 'VERSION=%s\n' "$VERSION" >> "$GITHUB_ENV"
 
       - name: Build Dokka
-        run: ./gradlew dokkaGenerateHtml -Pversion=${{ env.VERSION }}
+        run: ./gradlew dokkaGenerateHtml -Pversion="${{ env.VERSION }}"
 
       - name: Publish documentation
         uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # ratchet:JamesIves/github-pages-deploy-action@v4.8.0

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -30,6 +30,9 @@ jobs:
         # Fail fast if empty to avoid running Dokka with an empty version.
         run: |
           VERSION="${{ github.event.release.tag_name }}"
+          echo "[debug] github.event.release.tag_name='${VERSION}'"
+          echo "[debug] GITHUB_REF='${GITHUB_REF}'"
+          echo "[debug] GITHUB_REF_NAME='${GITHUB_REF_NAME}'"
           if [ -z "${VERSION}" ]; then
             echo "VERSION is empty (github.event.release.tag_name missing). Failing early."
             exit 1

--- a/.github/workflows/dokka.yml
+++ b/.github/workflows/dokka.yml
@@ -28,8 +28,9 @@ jobs:
         # Use release event payload as source of truth for version.
         # For `release: published`, `github.event.release.tag_name` contains the release tag.
         # Fail fast if empty to avoid running Dokka with an empty version.
+        env:
+          VERSION: ${{ github.event.release.tag_name }}
         run: |
-          VERSION="${{ github.event.release.tag_name }}"
           echo "[debug] github.event.release.tag_name='${VERSION}'"
           echo "[debug] GITHUB_REF='${GITHUB_REF}'"
           echo "[debug] GITHUB_REF_NAME='${GITHUB_REF_NAME}'"

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -34,21 +34,26 @@ jobs:
       #    username: ${{ secrets.DOCKERHUB_USERNAME }}
       #    password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Publish artifact and images
+        # Use release event payload as source of truth for version.
+        # For `release: published`, `github.event.release.tag_name` contains the release tag (e.g. 5.0.0).
+        # Fail fast if empty to avoid publishing with an empty Gradle version.
         env:
+          NEW_VERSION: ${{ github.event.release.tag_name }}
           ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.GPG_PASSPHRASE }}
           # must be an armored (i.e. ascii) private key _only_ (no public key block)
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        # The GITHUB_REF tag comes in the format 'refs/tags/xxx'.
-        # So if we split on '/' and take the 3rd value, we can get the release name.
         run: |
-          NEW_VERSION=$(echo "${GITHUB_REF}" | cut -d "/" -f3)
+          if [ -z "${NEW_VERSION}" ]; then
+            echo "NEW_VERSION is empty (github.event.release.tag_name missing). Failing early."
+            exit 1
+          fi
           IMAGE=${IMAGE_NAME}:${NEW_VERSION}
           IMAGE_DH=${IMAGE_NAME_DH}:${NEW_VERSION}
           echo "Releasing new version ${NEW_VERSION} of $IMAGE"
-          ./gradlew -Pversion=${NEW_VERSION} publishAllPublicationsToGithubPackagesRepository publishAndReleaseToMavenCentral --no-configuration-cache
+          ./gradlew -Pversion="${NEW_VERSION}" publishAllPublicationsToGithubPackagesRepository publishAndReleaseToMavenCentral --no-configuration-cache
           # ./gradlew jib --image="${IMAGE}" --image="${IMAGE_DH}"
           ./gradlew jib --image="${IMAGE}"
           MAJOR=$(echo "${NEW_VERSION}" | cut -d "." -f1)

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -46,6 +46,9 @@ jobs:
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.GPG_PRIVATE_KEY }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          echo "[debug] github.event.release.tag_name='${NEW_VERSION}'"
+          echo "[debug] GITHUB_REF='${GITHUB_REF}'"
+          echo "[debug] GITHUB_REF_NAME='${GITHUB_REF_NAME}'"
           if [ -z "${NEW_VERSION}" ]; then
             echo "NEW_VERSION is empty (github.event.release.tag_name missing). Failing early."
             exit 1


### PR DESCRIPTION
## Summary

This PR hardens release version resolution in release workflows.

## What changed

- Updated `.github/workflows/publish-release.yml`:
  - use `${{ github.event.release.tag_name }}` as source of truth for `NEW_VERSION`
  - fail fast if `NEW_VERSION` is empty
  - quote Gradle `-Pversion`
  - added debug output for:
    - `github.event.release.tag_name`
    - `GITHUB_REF`
    - `GITHUB_REF_NAME`

- Updated `.github/workflows/dokka.yml` similarly:
  - use `${{ github.event.release.tag_name }}` for `VERSION`
  - fail fast if empty
  - added same debug output

## Why

`GITHUB_REF` can be empty/unexpected in some release runs, which can lead to empty version publishing failures (`version cannot be empty`).
Using `release.tag_name` + fail-fast + debug logs makes release runs more reliable and easier to troubleshoot.