### PR TITLE
fix: apply CORS headers to error responses

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
@@ -118,7 +118,7 @@ internal class PathRouter(
         runCatching {
             routes.findHandler(request).invokeWith(request, interceptors)
         }.getOrElse {
-            exceptionHandler(request, it)
+            applyResponseInterceptors(request, exceptionHandler(request, it))
         }
 
     override fun toString(): String = routes.toString()
@@ -128,20 +128,21 @@ internal class PathRouter(
     private fun RequestHandler.invokeWith(
         request: OAuth2HttpRequest,
         interceptors: MutableList<Interceptor>,
+    ): OAuth2HttpResponse {
+        val filteredRequest =
+            interceptors.filterIsInstance<RequestInterceptor>().fold(request) { next, interceptor ->
+                interceptor.intercept(next)
+            }
+        val response = this.invoke(filteredRequest)
+        return applyResponseInterceptors(request, response)
+    }
+
+    private fun applyResponseInterceptors(
+        request: OAuth2HttpRequest,
+        response: OAuth2HttpResponse,
     ): OAuth2HttpResponse =
-        if (interceptors.size > 0) {
-            val filteredRequest =
-                interceptors.filterIsInstance<RequestInterceptor>().fold(request) { next, interceptor ->
-                    interceptor.intercept(next)
-                }
-            val res = this.invoke(filteredRequest)
-            val filteredResponse =
-                interceptors.filterIsInstance<ResponseInterceptor>().fold(res.copy()) { next, interceptor ->
-                    interceptor.intercept(request, next)
-                }
-            filteredResponse
-        } else {
-            this.invoke(request)
+        interceptors.filterIsInstance<ResponseInterceptor>().fold(response.copy()) { next, interceptor ->
+            interceptor.intercept(request, next)
         }
 
     private fun noMatch(request: OAuth2HttpRequest): OAuth2HttpResponse {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
@@ -13,6 +13,15 @@ fun interface RequestInterceptor : Interceptor {
     fun intercept(request: OAuth2HttpRequest): OAuth2HttpRequest
 }
 
+/**
+ * Intercepts and optionally transforms an outgoing response.
+ *
+ * Response interceptors are applied to normal responses and are also attempted for
+ * responses produced by the router exception handler.
+ *
+ * If a response interceptor throws while intercepting an exception-handler response,
+ * the interceptor failure is ignored and the original error response is returned.
+ */
 fun interface ResponseInterceptor : Interceptor {
     fun intercept(
         request: OAuth2HttpRequest,

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouter.kt
@@ -116,9 +116,15 @@ internal class PathRouter(
 
     override fun invoke(request: OAuth2HttpRequest): OAuth2HttpResponse =
         runCatching {
-            routes.findHandler(request).invokeWith(request, interceptors)
-        }.getOrElse {
-            applyResponseInterceptors(request, exceptionHandler(request, it))
+            val handlerResponse = routes.findHandler(request).invokeWith(request, interceptors)
+            applyResponseInterceptors(request, handlerResponse)
+        }.getOrElse { throwable ->
+            val errorResponse = exceptionHandler(request, throwable)
+            runCatching {
+                applyResponseInterceptors(request, errorResponse)
+            }.getOrElse {
+                errorResponse
+            }
         }
 
     override fun toString(): String = routes.toString()
@@ -133,8 +139,7 @@ internal class PathRouter(
             interceptors.filterIsInstance<RequestInterceptor>().fold(request) { next, interceptor ->
                 interceptor.intercept(next)
             }
-        val response = this.invoke(filteredRequest)
-        return applyResponseInterceptors(request, response)
+        return this.invoke(filteredRequest)
     }
 
     private fun applyResponseInterceptors(

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
@@ -11,6 +11,7 @@ import no.nav.security.mock.oauth2.http.CorsInterceptor.HeaderNames.ACCESS_CONTR
 import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
 import no.nav.security.mock.oauth2.testutils.options
+import no.nav.security.mock.oauth2.testutils.post
 import no.nav.security.mock.oauth2.testutils.tokenRequest
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.withMockOAuth2Server
@@ -106,15 +107,14 @@ class CorsHeadersIntegrationTest {
             client
                 .newCall(
                     Request.Builder().post(
-                        url = this.revocationEndpointUrl("default"),
-                        headers = Headers.headersOf("origin", origin),
-                        parameters =
-                            mapOf(
-                                "client_id" to "id",
-                                "client_secret" to "secret",
-                                "token" to "some-token",
-                                "token_type_hint" to "access_token",
-                            ),
+                        this.revocationEndpointUrl("default"),
+                        Headers.headersOf("origin", origin),
+                        mapOf(
+                            "client_id" to "id",
+                            "client_secret" to "secret",
+                            "token" to "some-token",
+                            "token_type_hint" to "access_token",
+                        ),
                     ),
                 ).execute()
                 .use {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/CorsHeadersIntegrationTest.kt
@@ -15,6 +15,7 @@ import no.nav.security.mock.oauth2.testutils.tokenRequest
 import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import no.nav.security.mock.oauth2.withMockOAuth2Server
 import okhttp3.Headers
+import okhttp3.Request
 import org.junit.jupiter.api.Test
 
 class CorsHeadersIntegrationTest {
@@ -96,6 +97,33 @@ class CorsHeadersIntegrationTest {
             response.code shouldBe 200
             response.headers[ACCESS_CONTROL_ALLOW_ORIGIN] shouldBe origin
             response.headers[ACCESS_CONTROL_ALLOW_CREDENTIALS] shouldBe "true"
+        }
+    }
+
+    @Test
+    fun `revoke error response should allow origin`() {
+        withMockOAuth2Server {
+            client
+                .newCall(
+                    Request.Builder().post(
+                        url = this.revocationEndpointUrl("default"),
+                        headers = Headers.headersOf("origin", origin),
+                        parameters =
+                            mapOf(
+                                "client_id" to "id",
+                                "client_secret" to "secret",
+                                "token" to "some-token",
+                                "token_type_hint" to "access_token",
+                            ),
+                    ),
+                ).execute()
+                .use {
+                    it.asClue {
+                        it.code shouldBe 400
+                        it.headers[ACCESS_CONTROL_ALLOW_ORIGIN] shouldBe origin
+                        it.headers[ACCESS_CONTROL_ALLOW_CREDENTIALS] shouldBe "true"
+                    }
+                }
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouterTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouterTest.kt
@@ -111,6 +111,35 @@ internal class OAuth2HttpRouterTest {
     }
 
     @Test
+    fun `response interceptors should be applied when route handler throws and exception handler returns a response`() {
+        val routes =
+            routes {
+                interceptors(
+                    ResponseInterceptor { _, response ->
+                        val headers =
+                            response.headers
+                                .newBuilder()
+                                .add("fromInterceptor", "fromInterceptor")
+                                .build()
+                        response.copy(headers = headers)
+                    },
+                )
+                exceptionHandler { _, _ ->
+                    OAuth2HttpResponse(status = 400, body = "fromExceptionHandler")
+                }
+                get("/boom") {
+                    error("boom")
+                }
+            }
+
+        routes.invoke(get("/boom")).asClue {
+            it.status shouldBe 400
+            it.headers shouldContain ("fromInterceptor" to "fromInterceptor")
+            it.body shouldBe "fromExceptionHandler"
+        }
+    }
+
+    @Test
     fun `routes with wildcard should be matched`() {
         val routes =
             routes(

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouterTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRouterTest.kt
@@ -140,6 +140,29 @@ internal class OAuth2HttpRouterTest {
     }
 
     @Test
+    fun `exception handler response should still be returned when response interceptor throws in error path`() {
+        val routes =
+            routes {
+                interceptors(
+                    ResponseInterceptor { _, _ ->
+                        error("interceptor boom")
+                    },
+                )
+                exceptionHandler { _, _ ->
+                    OAuth2HttpResponse(status = 400, body = "fromExceptionHandler")
+                }
+                get("/boom") {
+                    error("boom")
+                }
+            }
+
+        routes.invoke(get("/boom")).asClue {
+            it.status shouldBe 400
+            it.body shouldBe "fromExceptionHandler"
+        }
+    }
+
+    @Test
     fun `routes with wildcard should be matched`() {
         val routes =
             routes(


### PR DESCRIPTION
Fixes #964

## What

This PR ensures that response interceptors are also applied to responses produced by the router exception path.

In practice, this fixes missing CORS headers on error responses such as:
- `POST /{issuer}/revoke` with `token_type_hint=access_token`

## Why

Previously, normal responses went through response interceptors, but responses returned from `exceptionHandler(...)` did not.

That meant endpoints could return correct CORS headers on success, but miss them on errors, which breaks browser-based clients.

## Changes

- apply response interceptors to exception-handler responses in `OAuth2HttpRouter`
- add an integration test covering the revoke error case with an `Origin` header
- add a focused router test verifying that response interceptors are executed on exception responses
