### PR TITLE
fix: return empty body from revoke response

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -167,7 +167,7 @@ class OAuth2HttpRequestHandler(
                     )
                 }
             }
-            OAuth2HttpResponse(status = 200, body = "ok")
+            OAuth2HttpResponse(status = 200)
         }
 
     private fun Route.Builder.token() =

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RevocationIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/RevocationIntegrationTest.kt
@@ -43,7 +43,10 @@ class RevocationIntegrationTest {
                         "token_type_hint" to "refresh_token",
                     ),
                 )
-            revocationResponse.use { it.code shouldBe 200 }
+            revocationResponse.use {
+                it.code shouldBe 200
+                it.body.string() shouldBe ""
+            }
 
             // after revocation, using the revoked refresh token must return 400 invalid_grant
             client


### PR DESCRIPTION
Fixes #965

## What

Changes the revoke success response to return `200 OK` with an empty body instead of the plain text body `"ok"`.

## Why

RFC7009 §2.2 states that the client should rely on the HTTP status code and ignore the response body for a successful revocation response.

This change aligns the revoke endpoint more closely with the specification and avoids client-side parsing problems with libraries that incorrectly attempt to parse the plain text `"ok"` body.

## Compatibility note

This is not a breaking change in the RFC7009 contract, since clients are expected to ignore the revoke success response body.

However, it may be a compatibility-affecting behavioral change for non-compliant clients that were depending on the previous `"ok"` payload.

## Changes

- return `200` with an empty body for successful revoke requests
- update revocation integration test to verify the empty-body behavior
