### PR TITLE
fix: support subject request mappings for password grant

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/PasswordGrantHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/PasswordGrantHandler.kt
@@ -8,6 +8,7 @@ import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
+import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
 import okhttp3.HttpUrl
 
 internal class PasswordGrantHandler(
@@ -20,7 +21,11 @@ internal class PasswordGrantHandler(
     ): OAuth2TokenResponse {
         val tokenRequest = request.asNimbusTokenRequest()
         val scope: String? = tokenRequest.scope?.toString()
-        val passwordGrantTokenCallback = PasswordGrantTokenCallback(oAuth2TokenCallback)
+        val username =
+            tokenRequest.authorizationGrant
+                ?.let { it as? ResourceOwnerPasswordCredentialsGrant }
+                ?.username
+        val passwordGrantTokenCallback = PasswordGrantTokenCallback(oAuth2TokenCallback, username)
         val accessToken: SignedJWT = tokenProvider.accessToken(tokenRequest, issuerUrl, passwordGrantTokenCallback)
         val idToken: SignedJWT = tokenProvider.idToken(tokenRequest, issuerUrl, passwordGrantTokenCallback, null)
 
@@ -35,10 +40,29 @@ internal class PasswordGrantHandler(
 
     private class PasswordGrantTokenCallback(
         private val tokenCallback: OAuth2TokenCallback,
-    ) : OAuth2TokenCallback by tokenCallback {
-        override fun subject(tokenRequest: TokenRequest) =
-            tokenRequest.authorizationGrant
-                ?.let { it as? ResourceOwnerPasswordCredentialsGrant }
-                ?.username ?: tokenCallback.subject(tokenRequest)
+        private val username: String?,
+    ) : OAuth2TokenCallback {
+        private val resolvedDelegate: OAuth2TokenCallback =
+            when {
+                username != null && tokenCallback is RequestMappingTokenCallback -> {
+                    tokenCallback.withExtraMatchParams(mapOf(RequestMappingTokenCallback.SUBJECT_PARAM to username))
+                }
+
+                else -> {
+                    tokenCallback
+                }
+            }
+
+        override fun issuerId(): String = tokenCallback.issuerId()
+
+        override fun subject(tokenRequest: TokenRequest) = username ?: tokenCallback.subject(tokenRequest)
+
+        override fun typeHeader(tokenRequest: TokenRequest): String = resolvedDelegate.typeHeader(tokenRequest)
+
+        override fun audience(tokenRequest: TokenRequest): List<String> = resolvedDelegate.audience(tokenRequest)
+
+        override fun addClaims(tokenRequest: TokenRequest): Map<String, Any> = resolvedDelegate.addClaims(tokenRequest)
+
+        override fun tokenExpiry(): Long = tokenCallback.tokenExpiry()
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/PasswordGrantIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/PasswordGrantIntegrationTest.kt
@@ -2,23 +2,29 @@ package no.nav.security.mock.oauth2.e2e
 
 import com.nimbusds.oauth2.sdk.GrantType
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
+import no.nav.security.mock.oauth2.OAuth2Config
 import no.nav.security.mock.oauth2.testutils.ParsedTokenResponse
 import no.nav.security.mock.oauth2.testutils.audience
+import no.nav.security.mock.oauth2.testutils.claims
 import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.shouldBeValidFor
 import no.nav.security.mock.oauth2.testutils.subject
 import no.nav.security.mock.oauth2.testutils.toTokenResponse
 import no.nav.security.mock.oauth2.testutils.tokenRequest
 import no.nav.security.mock.oauth2.testutils.verifyWith
+import no.nav.security.mock.oauth2.token.RequestMapping
+import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
 import no.nav.security.mock.oauth2.withMockOAuth2Server
 import org.junit.jupiter.api.Test
 
 class PasswordGrantIntegrationTest {
     private val client = client()
+    private val requiredClaimsWithoutAudience = listOf("sub", "iss", "iat", "exp")
 
     @Test
     fun `token request with password grant should return accesstoken with username as subject`() {
@@ -48,6 +54,104 @@ class PasswordGrantIntegrationTest {
             response.idToken should verifyWith(issuerId, this)
             response.idToken.subject shouldBe "foo"
             response.idToken.audience shouldContainExactly listOf("client")
+        }
+    }
+
+    @Test
+    fun `password grant supports requestMapping match on subject and exposes subject template variable`() {
+        val issuerId = "default"
+        val requestMappingCallback =
+            RequestMappingTokenCallback(
+                issuerId = issuerId,
+                requestMappings =
+                    listOf(
+                        RequestMapping(
+                            requestParam = RequestMappingTokenCallback.SUBJECT_PARAM,
+                            match = "admin",
+                            claims = mapOf("role" to "admin", "preferred_username" to "\${subject}"),
+                        ),
+                    ),
+            )
+
+        withMockOAuth2Server(
+            OAuth2Config(
+                tokenCallbacks = setOf(requestMappingCallback),
+            ),
+        ) {
+            val response: ParsedTokenResponse =
+                client
+                    .tokenRequest(
+                        url = this.tokenEndpointUrl(issuerId),
+                        basicAuth = Pair("client", "secret"),
+                        parameters =
+                            mapOf(
+                                "grant_type" to GrantType.PASSWORD.value,
+                                "scope" to "scope1",
+                                "username" to "admin",
+                                "password" to "bar",
+                            ),
+                    ).toTokenResponse()
+
+            response shouldBeValidFor GrantType.PASSWORD
+            response.accessToken.shouldNotBeNull()
+            response.accessToken should verifyWith(issuerId, this, requiredClaimsWithoutAudience)
+            response.accessToken.subject shouldBe "admin"
+            response.accessToken.claims shouldContainAll mapOf("role" to "admin", "preferred_username" to "admin")
+
+            response.idToken.shouldNotBeNull()
+            response.idToken should verifyWith(issuerId, this, requiredClaimsWithoutAudience)
+            response.idToken.subject shouldBe "admin"
+            response.idToken.claims shouldContainAll mapOf("role" to "admin", "preferred_username" to "admin")
+        }
+    }
+
+    @Test
+    fun `password grant does not apply subject requestMapping when username does not match`() {
+        val issuerId = "default"
+        val requestMappingCallback =
+            RequestMappingTokenCallback(
+                issuerId = issuerId,
+                requestMappings =
+                    listOf(
+                        RequestMapping(
+                            requestParam = RequestMappingTokenCallback.SUBJECT_PARAM,
+                            match = "admin",
+                            claims = mapOf("role" to "admin", "preferred_username" to "\${subject}"),
+                        ),
+                    ),
+            )
+
+        withMockOAuth2Server(
+            OAuth2Config(
+                tokenCallbacks = setOf(requestMappingCallback),
+            ),
+        ) {
+            val response: ParsedTokenResponse =
+                client
+                    .tokenRequest(
+                        url = this.tokenEndpointUrl(issuerId),
+                        basicAuth = Pair("client", "secret"),
+                        parameters =
+                            mapOf(
+                                "grant_type" to GrantType.PASSWORD.value,
+                                "scope" to "scope1",
+                                "username" to "user",
+                                "password" to "bar",
+                            ),
+                    ).toTokenResponse()
+
+            response shouldBeValidFor GrantType.PASSWORD
+            response.accessToken.shouldNotBeNull()
+            response.accessToken should verifyWith(issuerId, this, requiredClaimsWithoutAudience)
+            response.accessToken.subject shouldBe "user"
+            response.accessToken.claims["role"] shouldBe null
+            response.accessToken.claims["preferred_username"] shouldBe null
+
+            response.idToken.shouldNotBeNull()
+            response.idToken should verifyWith(issuerId, this, requiredClaimsWithoutAudience)
+            response.idToken.subject shouldBe "user"
+            response.idToken.claims["role"] shouldBe null
+            response.idToken.claims["preferred_username"] shouldBe null
         }
     }
 }


### PR DESCRIPTION
## What

This adds support for `requestParam = \"subject\"` in the password grant flow (`/token` with `grant_type=password`) without requiring duplicated mappings for both `subject` and `username`.

## Changes

- injects `subject=username` as `extraMatchParams` for `RequestMappingTokenCallback` in the password grant flow
- keeps the final token `sub` equal to `username`
- resolves the wrapped callback once per request in the password-grant wrapper
- removes interface delegation in the password-grant wrapper in favor of explicit forwarding for clearer and safer behavior

## Tests

Adds integration tests for:
- positive case: `username=admin` matches a mapping on `subject` and `${subject}` resolves to `admin`
- negative case: a non-matching `username` does not apply mapping claims

## Why

This addresses the concern raised in this issue comment:
https://github.com/navikt/mock-oauth2-server/issues/942#issuecomment-4924916704

After this change, a password grant request can use a `subject` request mapping directly, so duplicating config for both `subject` and `username` is no longer necessary for this scenario.

## Verification

Validated with targeted password grant tests.

Note:
The full test suite may still fail because of a separate existing flaky test:
`OAuth2HttpServerTest > MockWebServer should start and serve requests with generated keystore and HTTPS enabled()`