### PR TITLE
build: move kotlinx-serialization-json to testImplementation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,7 +85,7 @@ dependencies {
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("org.freemarker:freemarker:$freemarkerVersion")
     implementation("org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-params:$junitJupiterVersion")


### PR DESCRIPTION
Only used in test code (the Ktor example in `OAuth2LoginApp.kt`). Nothing in
`src/main` references it.

As `implementation` it still lands in the published POM with runtime scope, so
it becomes a transitive dependency for all consumers, including those who
declare mock-oauth2-server as `testImplementation`