### PR TITLE
build: keep logback-classic out of the published artifact

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -73,11 +73,20 @@ repositories {
     mavenCentral()
 }
 
+// Dependencies needed only when running the standalone server (Docker image via jib).
+// runtimeClasspath extends this, runtimeElements does not, so these stay out of the
+// published POM/module metadata and off library consumers' classpaths.
+val standaloneRuntime = configurations.dependencyScope("standaloneRuntime")
+configurations.runtimeClasspath {
+    extendsFrom(standaloneRuntime.get())
+}
+
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
     implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
-    implementation("ch.qos.logback:logback-classic:$logbackVersion")
+    add(standaloneRuntime.name, "ch.qos.logback:logback-classic:$logbackVersion")
+    testRuntimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
     api("com.squareup.okhttp3:mockwebserver:$mockWebServerVersion")
     api("com.nimbusds:oauth2-oidc-sdk:$nimbusSdkVersion")
     implementation("io.netty:netty-codec-http:$nettyVersion")

--- a/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2Server.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2
 
-import ch.qos.logback.classic.ClassicConstants
 import no.nav.security.mock.oauth2.StandaloneConfig.hostname
 import no.nav.security.mock.oauth2.StandaloneConfig.oauth2Config
 import no.nav.security.mock.oauth2.StandaloneConfig.port
@@ -49,7 +48,9 @@ object StandaloneConfig {
 }
 
 fun main() {
-    System.setProperty(ClassicConstants.CONFIG_FILE_PROPERTY, "LOGBACK_CONFIG".fromEnv("logback-standalone.xml"))
+    // Literal instead of ch.qos.logback.classic.ClassicConstants: logback is a runtime-only
+    // dependency of the standalone server and must not leak onto library consumers' classpath.
+    System.setProperty("logback.configurationFile", "LOGBACK_CONFIG".fromEnv("logback-standalone.xml"))
     MockOAuth2Server(
         oauth2Config(),
         route("/isalive") {


### PR DESCRIPTION
`logback-classic` was `implementation`, so it landed in the published POM with
runtime scope and became a transitive dependency for every consumer. A library
shouldn't ship a logging backend as it overrides consumers' own logback version
and can cause SLF4J binding conflicts.

Its only use in `src/main` is setting the logback config property in `fun main()`,
i.e. the standalone server, which still gets it.

Release note: consumers relying on inheriting logback from us will see "No SLF4J
providers were found" until they add a backend. `slf4j-api` still comes
transitively via kotlin-logging.