### PR TITLE
fix: restrict the debugger to this server's own endpoints

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/debugger/Client.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/debugger/Client.kt
@@ -43,20 +43,20 @@ internal class TokenRequest(
             } +
             "\n\n$body"
 
-    private fun HttpUrl.toHostHeader(includeDefaultPort: Boolean = false): String {
-        val host = if (":" in host) "[$host]" else host
-        return if (includeDefaultPort || port != HttpUrl.defaultPort(scheme)) {
-            "$host:$port"
-        } else {
-            host
-        }
-    }
-
     private fun Map<String, String>.toKeyValueString(entrySeparator: String): String =
         this
             .map { "${it.key}=${it.value}" }
             .toList()
             .joinToString(entrySeparator)
+}
+
+internal fun HttpUrl.toHostHeader(includeDefaultPort: Boolean = false): String {
+    val host = if (":" in host) "[$host]" else host
+    return if (includeDefaultPort || port != HttpUrl.defaultPort(scheme)) {
+        "$host:$port"
+    } else {
+        host
+    }
 }
 
 internal data class ClientAuthentication(
@@ -88,13 +88,21 @@ internal data class ClientAuthentication(
 
 internal fun String.urlEncode(): String = URLEncoder.encode(this, StandardCharsets.UTF_8)
 
-internal fun OkHttpClient.post(tokenRequest: TokenRequest): String =
+// target is the address the request is actually sent to, while the headers reproduce the url the client
+// sees, so that the issued token carries the issuer a real client would get
+internal fun OkHttpClient.post(
+    tokenRequest: TokenRequest,
+    target: HttpUrl,
+): String =
     this
         .newCall(
             Request
                 .Builder()
                 .headers(tokenRequest.headers)
-                .url(tokenRequest.url)
+                .header("Host", tokenRequest.url.toHostHeader())
+                .header("x-forwarded-proto", tokenRequest.url.scheme)
+                .header("x-forwarded-port", tokenRequest.url.port.toString())
+                .url(target)
                 .post(tokenRequest.body.toRequestBody("application/x-www-form-urlencoded".toMediaType()))
                 .build(),
         ).execute()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandler.kt
@@ -73,17 +73,20 @@ private fun Route.Builder.debuggerForm(sessionManager: SessionManager) =
             log.debug("handling POST request, return redirect")
             // the debugger only ever drives this server's own flow, so the endpoint comes from the request url
             // and not from the submitted form, which would make this an open redirect
+            val callbackUrl = it.url.toDebuggerCallbackUrl().toString()
             val httpUrl =
                 it.url
                     .toAuthorizationEndpointUrl()
                     .newBuilder()
                     .encodedQuery(it.formParameters.parameterString)
-                    .removeAllEncodedQueryParams("authorize_url", "token_url", "client_secret", "client_auth_method")
+                    .removeAllEncodedQueryParams("authorize_url", "token_url", "client_secret", "client_auth_method", "redirect_uri")
+                    // a callback elsewhere cannot validate state or nonce, as it never initiated the flow
+                    .addQueryParameter("redirect_uri", callbackUrl)
                     .build()
 
             log.debug("attempting to redirect to $httpUrl, setting received params in encrypted cookie")
             val session = sessionManager.session(it)
-            session.putAll(it.formParameters.map)
+            session.putAll(it.formParameters.map + ("redirect_uri" to callbackUrl))
             redirect(httpUrl.toString(), Headers.headersOf("Set-Cookie", session.asCookie()))
         }
     }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandler.kt
@@ -5,12 +5,16 @@ import mu.KotlinLogging
 import no.nav.security.mock.oauth2.OAuth2Exception
 import no.nav.security.mock.oauth2.extensions.OAuth2Endpoints.DEBUGGER
 import no.nav.security.mock.oauth2.extensions.OAuth2Endpoints.DEBUGGER_CALLBACK
+import no.nav.security.mock.oauth2.extensions.OAuth2Endpoints.TOKEN
+import no.nav.security.mock.oauth2.extensions.issuerId
 import no.nav.security.mock.oauth2.extensions.removeAllEncodedQueryParams
 import no.nav.security.mock.oauth2.extensions.toAuthorizationEndpointUrl
 import no.nav.security.mock.oauth2.extensions.toDebuggerCallbackUrl
 import no.nav.security.mock.oauth2.extensions.toDebuggerUrl
+import no.nav.security.mock.oauth2.extensions.toTokenEndpointUrl
 import no.nav.security.mock.oauth2.http.ExceptionHandler
 import no.nav.security.mock.oauth2.http.OAuth2HttpResponse
+import no.nav.security.mock.oauth2.http.OAuth2HttpServer
 import no.nav.security.mock.oauth2.http.Route
 import no.nav.security.mock.oauth2.http.Ssl
 import no.nav.security.mock.oauth2.http.html
@@ -19,20 +23,19 @@ import no.nav.security.mock.oauth2.http.routes
 import no.nav.security.mock.oauth2.http.templateMapper
 import okhttp3.Headers
 import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 
 private val log = KotlinLogging.logger { }
 private val client: OkHttpClient = OkHttpClient().newBuilder().build()
 
 class DebuggerRequestHandler(
+    httpServer: OAuth2HttpServer,
     sessionManager: SessionManager = SessionManager(),
-    ssl: Ssl? = null,
     route: Route =
         routes {
             exceptionHandler(handle(sessionManager))
             debuggerForm(sessionManager)
-            debuggerCallback(sessionManager, ssl)
+            debuggerCallback(sessionManager, httpServer::url, httpServer.sslConfig())
         },
 ) : Route by route
 
@@ -68,10 +71,11 @@ private fun Route.Builder.debuggerForm(sessionManager: SessionManager) =
         }
         post(DEBUGGER) {
             log.debug("handling POST request, return redirect")
-            val authorizeUrl = it.formParameters.get("authorize_url") ?: error("authorize_url is missing")
+            // the debugger only ever drives this server's own flow, so the endpoint comes from the request url
+            // and not from the submitted form, which would make this an open redirect
             val httpUrl =
-                authorizeUrl
-                    .toHttpUrl()
+                it.url
+                    .toAuthorizationEndpointUrl()
                     .newBuilder()
                     .encodedQuery(it.formParameters.parameterString)
                     .removeAllEncodedQueryParams("authorize_url", "token_url", "client_secret", "client_auth_method")
@@ -86,11 +90,15 @@ private fun Route.Builder.debuggerForm(sessionManager: SessionManager) =
 
 private fun Route.Builder.debuggerCallback(
     sessionManager: SessionManager,
+    serverUrl: (String) -> HttpUrl,
     ssl: Ssl? = null,
 ) = any(DEBUGGER_CALLBACK) {
     log.debug("handling ${it.method} request to debugger callback")
     val session = sessionManager.session(it)
-    val tokenUrl: HttpUrl = session["token_url"].toHttpUrl()
+    // the request is sent to the server's own bound address, never to a url derived from the request itself:
+    // request urls are proxy aware, so a client controlled Host header would otherwise pick the target
+    val target = serverUrl(it.url.tokenEndpointPath()).viaLoopbackIfWildcard()
+    val tokenUrl: HttpUrl = it.url.toTokenEndpointUrl()
     val code: String =
         it.url.queryParameter("code")
             ?: it.formParameters.get("code")
@@ -109,9 +117,14 @@ private fun Route.Builder.debuggerCallback(
         )
     val response =
         if (ssl != null) {
-            client.withSsl(ssl).post(request)
+            client.withSsl(ssl).post(request, target)
         } else {
-            client.post(request)
+            client.post(request, target)
         }
     html(templateMapper.debuggerCallbackHtml(request.toString(), response))
 }
+
+private fun HttpUrl.tokenEndpointPath(): String = issuerId().let { if (it.isEmpty()) TOKEN else "/$it$TOKEN" }
+
+// a server bound to a wildcard address reports it as its host, which is not connectable
+private fun HttpUrl.viaLoopbackIfWildcard(): HttpUrl = if (host in setOf("0.0.0.0", "::")) newBuilder().host("localhost").build() else this

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestHandler.kt
@@ -57,7 +57,7 @@ class OAuth2HttpRequestHandler(
     private val config: OAuth2Config,
 ) {
     private val loginRequestHandler = LoginRequestHandler(templateMapper, config)
-    private val debuggerRequestHandler = DebuggerRequestHandler(ssl = config.httpServer.sslConfig())
+    private val debuggerRequestHandler = DebuggerRequestHandler(config.httpServer)
     private val tokenCallbackQueue: BlockingQueue<OAuth2TokenCallback> = LinkedBlockingQueue()
     private val refreshTokenManager = RefreshTokenManager()
 

--- a/src/main/resources/templates/debugger.ftl
+++ b/src/main/resources/templates/debugger.ftl
@@ -12,11 +12,9 @@
             <div>
                 <form method="post">
                     <label for="authorize_url">Authorization Endpoint</label>
-                    <input class="u-full-width" type="text" placeholder="The Authorization endpoint of your ID provider"
-                           name="authorize_url" value="${url}">
-                    <label for="authorize_url">Token Endpoint</label>
-                    <input class="u-full-width" type="text" placeholder="The Token endpoint of your ID provider"
-                           name="token_url" value="${token_url}">
+                    <input class="u-full-width" type="text" name="authorize_url" value="${url}" readonly>
+                    <label for="token_url">Token Endpoint</label>
+                    <input class="u-full-width" type="text" name="token_url" value="${token_url}" readonly>
                     <label for="client_auth_method">Client Authentication Method</label>
                     <input class="u-full-width" type="text" placeholder="Client auth method" name="client_auth_method"
                            value="${client_auth_method}">

--- a/src/main/resources/templates/debugger.ftl
+++ b/src/main/resources/templates/debugger.ftl
@@ -8,7 +8,7 @@
 
         <div class="docs-section" id="openid">
             <h6 class="docs-header">OpenID Connect</h6>
-            <p>Insert your parameters here to get a token from your Identity Provider</p>
+            <p>Insert your parameters here to run the Authorization Code Flow against this server</p>
             <div>
                 <form method="post">
                     <label for="authorize_url">Authorization Endpoint</label>
@@ -19,10 +19,10 @@
                     <input class="u-full-width" type="text" placeholder="Client auth method" name="client_auth_method"
                            value="${client_auth_method}">
                     <label for="client_id">Client Id</label>
-                    <input class="u-full-width" type="text" placeholder="Your registered client_id" name="client_id"
+                    <input class="u-full-width" type="text" placeholder="Any client_id, this server does not require registration" name="client_id"
                            value="${query.client_id}">
                     <label for="client_secret">Client Secret (used to acquire token when callback is received)</label>
-                    <input class="u-full-width" type="text" placeholder="Your registered client_secret"
+                    <input class="u-full-width" type="text" placeholder="Any client_secret, this server does not require registration"
                            name="client_secret" value="someSecret">
                     <label for="scope">Scope</label>
                     <input class="u-full-width" type="text"
@@ -42,11 +42,9 @@
                            placeholder="A nonce value to include in token (for replay protection)" name="nonce"
                            value="${query.nonce}">
                     <label for="redirect_uri">Redirect URI (callback)</label>
-                    <p style="margin-bottom: 0.5rem; color: grey">Should be a preregistered URL at your identity
-                        provider. If using the mock-oauth2-server any URL will suffice</p>
-                    <input class="u-full-width" type="text"
-                           placeholder="The location where code or token should be sent after login" name="redirect_uri"
-                           value="${query.redirect_uri}">
+                    <p style="margin-bottom: 0.5rem; color: grey">The debugger's own callback, which completes the
+                        flow and displays the token response</p>
+                    <input class="u-full-width" type="text" name="redirect_uri" value="${query.redirect_uri}" readonly>
                     <input class="button-primary" type="submit" value="Get a token">
                 </form>
             </div>

--- a/src/test/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandlerTest.kt
@@ -1,0 +1,167 @@
+package no.nav.security.mock.oauth2.debugger
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
+import no.nav.security.mock.oauth2.MockOAuth2Server
+import no.nav.security.mock.oauth2.OAuth2Config
+import no.nav.security.mock.oauth2.http.NettyWrapper
+import no.nav.security.mock.oauth2.http.Ssl
+import no.nav.security.mock.oauth2.http.SslKeystore
+import okhttp3.FormBody
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.jupiter.api.Test
+import java.io.File
+import java.net.InetAddress
+
+internal class DebuggerRequestHandlerTest {
+    private val client = OkHttpClient().newBuilder().followRedirects(false).build()
+
+    @Test
+    fun `debugger callback should not make server side requests to a client supplied token_url`() {
+        val internalService = MockWebServer()
+        internalService.enqueue(MockResponse().setBody("INTERNAL_SECRET"))
+        internalService.start()
+
+        val server = MockOAuth2Server()
+        server.start()
+
+        try {
+            val ssrfTarget = internalService.url("/secret-internal-endpoint")
+            val debuggerUrl = server.url("/default/debugger")
+
+            val form =
+                FormBody
+                    .Builder()
+                    .add("authorize_url", server.url("/default/authorize").toString())
+                    .add("token_url", ssrfTarget.toString())
+                    .add("client_id", "debugger")
+                    .add("client_secret", "secret")
+                    .add("client_auth_method", "CLIENT_SECRET_BASIC")
+                    .add("scope", "openid")
+                    .add("redirect_uri", server.url("/default/debugger/callback").toString())
+                    .build()
+
+            val cookie =
+                client
+                    .newCall(
+                        Request
+                            .Builder()
+                            .url(debuggerUrl)
+                            // spoofed to match the SSRF target, defeating any same origin check on the request url
+                            .header("Host", "${ssrfTarget.host}:${ssrfTarget.port}")
+                            .post(form)
+                            .build(),
+                    ).execute()
+                    .use { checkNotNull(it.header("Set-Cookie")) }
+
+            val callbackBody =
+                client
+                    .newCall(
+                        Request
+                            .Builder()
+                            .url(server.url("/default/debugger/callback?code=some-code"))
+                            .header("Host", "${ssrfTarget.host}:${ssrfTarget.port}")
+                            .header("Cookie", cookie.substringBefore(";"))
+                            .build(),
+                    ).execute()
+                    .use { it.body.string() }
+
+            internalService.requestCount shouldBe 0
+            callbackBody shouldNotContain "INTERNAL_SECRET"
+            // the client visible url is still reflected in the request, it just no longer selects the target
+            callbackBody shouldContain "Host: ${ssrfTarget.host}:${ssrfTarget.port}"
+        } finally {
+            server.shutdown()
+            internalService.shutdown()
+        }
+    }
+
+    @Test
+    fun `debugger should not redirect to a client supplied authorize_url`() {
+        val server = MockOAuth2Server()
+        server.start()
+
+        try {
+            val form =
+                FormBody
+                    .Builder()
+                    .add("authorize_url", "http://evil.example.com/authorize")
+                    .add("client_id", "debugger")
+                    .add("scope", "openid")
+                    .build()
+
+            client
+                .newCall(
+                    Request
+                        .Builder()
+                        .url(server.url("/default/debugger"))
+                        .post(form)
+                        .build(),
+                ).execute()
+                .use {
+                    it.code shouldBe 302
+                    checkNotNull(it.header("Location")) shouldStartWith server.url("/default/authorize").toString()
+                }
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    @Test
+    fun `debugger callback should reach the token endpoint over https with a provided keystore`() {
+        val ssl =
+            Ssl(
+                SslKeystore(
+                    keyPassword = "",
+                    keystoreFile = File("src/test/resources/localhost.p12"),
+                    keystorePassword = "",
+                    keystoreType = SslKeystore.KeyStoreType.PKCS12,
+                ),
+            )
+        val server = MockOAuth2Server(OAuth2Config(httpServer = NettyWrapper(ssl)))
+        // the wildcard bind of the standalone server, an address no certificate covers
+        server.start(InetAddress.getByName("0.0.0.0"), 0)
+        val sslClient = client.withSsl(ssl)
+
+        try {
+            val base = "https://localhost:${server.url("/").port}"
+            val form =
+                FormBody
+                    .Builder()
+                    .add("client_id", "debugger")
+                    .add("client_secret", "secret")
+                    .add("client_auth_method", "CLIENT_SECRET_BASIC")
+                    .add("scope", "openid")
+                    .add("redirect_uri", "$base/default/debugger/callback")
+                    .build()
+
+            val cookie =
+                sslClient
+                    .newCall(
+                        Request
+                            .Builder()
+                            .url("$base/default/debugger")
+                            .post(form)
+                            .build(),
+                    ).execute()
+                    .use { checkNotNull(it.header("Set-Cookie")) }
+
+            sslClient
+                .newCall(
+                    Request
+                        .Builder()
+                        .url("$base/default/debugger/callback?code=some-code")
+                        .header("Cookie", cookie.substringBefore(";"))
+                        .build(),
+                ).execute()
+                .use { it.body.string() } shouldContain "invalid_grant"
+        } finally {
+            server.shutdown()
+        }
+    }
+}

--- a/src/test/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/debugger/DebuggerRequestHandlerTest.kt
@@ -10,6 +10,7 @@ import no.nav.security.mock.oauth2.http.NettyWrapper
 import no.nav.security.mock.oauth2.http.Ssl
 import no.nav.security.mock.oauth2.http.SslKeystore
 import okhttp3.FormBody
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -91,6 +92,7 @@ internal class DebuggerRequestHandlerTest {
                 FormBody
                     .Builder()
                     .add("authorize_url", "http://evil.example.com/authorize")
+                    .add("redirect_uri", "http://evil.example.com/callback")
                     .add("client_id", "debugger")
                     .add("scope", "openid")
                     .build()
@@ -105,7 +107,9 @@ internal class DebuggerRequestHandlerTest {
                 ).execute()
                 .use {
                     it.code shouldBe 302
-                    checkNotNull(it.header("Location")) shouldStartWith server.url("/default/authorize").toString()
+                    val location = checkNotNull(it.header("Location")).toHttpUrl()
+                    location.toString() shouldStartWith server.url("/default/authorize").toString()
+                    location.queryParameter("redirect_uri") shouldBe server.url("/default/debugger/callback").toString()
                 }
         } finally {
             server.shutdown()


### PR DESCRIPTION
The debugger callback POSTed to a `token_url` taken from a client-supplied cookie and rendered the response, letting anyone make the server call hosts they cannot reach themselves.
`POST /debugger` redirected to a client-supplied`authorize_url` the same way.

Both now come from the server. The token call goes to the bound address, since request urls are proxy-aware and a `Host` header would otherwise pick the target; the redirect keeps the proxy-aware url, which is what the browser has to reach.

## Breaking changes

- The debugger can no longer target an external identity provider. The endpoint
and `redirect_uri` fields are readonly; the rest stay editable.
- `DebuggerRequestHandler` takes an `OAuth2HttpServer` instead of an `Ssl?`.