### PR TITLE
fix: cap Netty request body aggregation at 1 MiB

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt
@@ -163,7 +163,7 @@ class NettyWrapper
                                 }
                                 ch.pipeline().addLast("codec", HttpServerCodec())
                                 ch.pipeline().addLast("keepAlive", HttpServerKeepAliveHandler())
-                                ch.pipeline().addLast("aggregator", HttpObjectAggregator(Int.MAX_VALUE))
+                                ch.pipeline().addLast("aggregator", HttpObjectAggregator(MAX_CONTENT_LENGTH))
                                 ch.pipeline().addLast("streamer", ChunkedWriteHandler())
                                 ch.pipeline().addLast("routes", RouterChannelHandler(requestHandler))
                             }
@@ -206,6 +206,11 @@ class NettyWrapper
         override fun sslConfig(): Ssl? = ssl
 
         private fun Ssl.nettySslHandler(): SslHandler = SslHandler(sslEngine())
+
+        companion object {
+            // OAuth2 request bodies are a few KB at most; cap aggregation so a large body cannot exhaust memory
+            private const val MAX_CONTENT_LENGTH = 1024 * 1024
+        }
 
         internal class RouterChannelHandler(
             val requestHandler: RequestHandler,

--- a/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
@@ -14,7 +14,10 @@ import no.nav.security.mock.oauth2.testutils.get
 import no.nav.security.mock.oauth2.testutils.post
 import no.nav.security.mock.oauth2.testutils.withTrustStore
 import okhttp3.Headers
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
 import org.junit.jupiter.api.Test
 import java.io.File
 
@@ -77,6 +80,25 @@ internal class OAuth2HttpServerTest {
                 ),
             )
         NettyWrapper(ssl).start(requestHandler).shouldServeRequests(ssl).stop()
+    }
+
+    @Test
+    fun `Netty server should reject request bodies exceeding the max content length`() {
+        val server = NettyWrapper().start(requestHandler)
+        try {
+            val oversizedBody = "a".repeat(1024 * 1024 + 1)
+            httpClient
+                .newCall(
+                    Request
+                        .Builder()
+                        .url(server.url("/form"))
+                        .post(oversizedBody.toRequestBody("text/plain".toMediaType()))
+                        .build(),
+                ).execute()
+                .use { it.code shouldBe 413 }
+        } finally {
+            server.stop()
+        }
     }
 
     @Test


### PR DESCRIPTION
NettyWrapper used `HttpObjectAggregator(Int.MAX_VALUE)`, so the whole request body was buffered before routing. Any unauthenticated client could send a large body to any endpoint and exhaust the heap. Affects the standalone/Docker server, which defaults to NettyWrapper.

Netty now answers 413 above the limit. OAuth2 request bodies are a few KB, so 1 MiB leaves ample headroom.