### PR TITLE
build(deps)!: migrate to Jackson 3

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,5 +1,49 @@
 # Migration guide
 
+## Migrating to 6.0.0
+
+### `logback-classic` and `kotlinx-serialization-json` are no longer bundled
+
+Both appeared in the published POM and ended up on consumers' classpaths. They are now test- and standalone-only.
+
+**Affected pattern:** relying on mock-oauth2-server to pull in an SLF4J binding or `kotlinx-serialization-json`.
+
+**Migration:** if your test logs went quiet, declare a binding yourself:
+
+```kotlin
+testRuntimeOnly("ch.qos.logback:logback-classic:<version>")
+```
+
+`slf4j-api` still comes transitively; only the binding is gone. If you used `kotlinx-serialization-json` without declaring it, add it explicitly. The standalone server and Docker image still ship with logback.
+
+### The debugger can no longer target an external identity provider
+
+The debugger callback POSTed to a `token_url` taken from a client-supplied cookie and rendered the response, so anyone could make the server call hosts they could not reach themselves. `POST /<issuer>/debugger` redirected to a client-supplied `authorize_url` the same way.
+
+**New behavior (6.0.0):** both endpoints come from the server. In the debugger form, the endpoint and `redirect_uri` fields are readonly; the rest stay editable. The `authorize_url`, `token_url`, `client_secret`, `client_auth_method` and `redirect_uri` form parameters are ignored.
+
+**Affected pattern:** using the debugger as a generic OAuth2 client against a third-party provider.
+
+**Migration:** none. Point a real client at the external provider instead. The debugger still works against this server's own issuers.
+
+If you construct `DebuggerRequestHandler` yourself, it now takes an `OAuth2HttpServer` instead of an `Ssl?`.
+
+### Jackson 3
+
+The library now uses Jackson 3 (`tools.jackson.*`) instead of Jackson 2 (`com.fasterxml.jackson.*`).
+
+**Consumers on Jackson 2 are unaffected.** Jackson 3 uses a different group ID and package, and still depends on `com.fasterxml.jackson.core:jackson-annotations:2.x`, so both can be on the classpath at once. The Ktor and Spring Boot example apps in this project's test suite stay on Jackson 2 and exercise that combination.
+
+**Affected pattern:** using the `no.nav.security.mock.oauth2.http.objectMapper` top-level property, or the `OAuth2TokenProviderDeserializer` and `OAuth2HttpServerDeserializer` classes nested in `OAuth2Config`.
+
+**Migration:** these are now `internal`, so the library no longer exposes Jackson types in its Kotlin API. Construct your own mapper if you used `objectMapper`.
+
+### `NettyWrapper` caps request bodies at 1 MiB
+
+Request bodies were aggregated with no limit, so any unauthenticated client could exhaust the heap by sending a large body to any endpoint.
+
+**New behavior (6.0.0):** `NettyWrapper` answers `413 Request Entity Too Large` above 1 MiB. Affects the standalone server and Docker image, which default to `NettyWrapper`. `MockWebServerWrapper` is unaffected.
+
 ## Migrating to 5.0.0
 
 ### Interactive login + `requestMappings`: claim precedence change

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,12 @@ val kotlinLoggingVersion = "3.0.5"
 val logbackVersion = "1.6.0"
 val nimbusSdkVersion = "11.38.2"
 val mockWebServerVersion = "5.4.0"
-val jacksonVersion = "2.22.1"
+val jacksonVersion = "3.2.1"
+
+// Ktor and Spring Boot are Jackson 2 only, so the example apps in src/test pull it in
+// alongside the Jackson 3 used by the library itself. Their BOMs lag behind, so pin the
+// floor here rather than inheriting whatever they happen to resolve to.
+val jackson2TestVersion = "2.22.1"
 val nettyVersion = "4.2.16.Final"
 val junitJupiterVersion = "6.1.2"
 val freemarkerVersion = "2.3.34"
@@ -84,16 +89,17 @@ configurations.runtimeClasspath {
 dependencies {
     implementation(kotlin("stdlib"))
     implementation(kotlin("reflect"))
-    implementation("com.fasterxml.jackson.core:jackson-databind:$jacksonVersion")
+    implementation("tools.jackson.core:jackson-databind:$jacksonVersion")
     add(standaloneRuntime.name, "ch.qos.logback:logback-classic:$logbackVersion")
     testRuntimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
     api("com.squareup.okhttp3:mockwebserver:$mockWebServerVersion")
     api("com.nimbusds:oauth2-oidc-sdk:$nimbusSdkVersion")
     implementation("io.netty:netty-codec-http:$nettyVersion")
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
+    implementation("tools.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("org.freemarker:freemarker:$freemarkerVersion")
     implementation("org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion")
+    testImplementation(platform("com.fasterxml.jackson:jackson-bom:$jackson2TestVersion"))
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")

--- a/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/OAuth2Config.kt
@@ -1,12 +1,5 @@
 package no.nav.security.mock.oauth2
 
-import com.fasterxml.jackson.core.JsonParser
-import com.fasterxml.jackson.databind.DeserializationContext
-import com.fasterxml.jackson.databind.JsonDeserializer
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.JWK
 import no.nav.security.mock.oauth2.http.MockWebServerWrapper
@@ -18,6 +11,13 @@ import no.nav.security.mock.oauth2.token.KeyProvider
 import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
+import tools.jackson.core.JsonParser
+import tools.jackson.databind.DeserializationContext
+import tools.jackson.databind.JsonNode
+import tools.jackson.databind.ValueDeserializer
+import tools.jackson.databind.annotation.JsonDeserialize
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.io.File
 import java.time.Instant
 
@@ -35,7 +35,7 @@ data class OAuth2Config
         @JsonDeserialize(using = OAuth2HttpServerDeserializer::class)
         val httpServer: OAuth2HttpServer = MockWebServerWrapper(),
     ) {
-        class OAuth2TokenProviderDeserializer : JsonDeserializer<OAuth2TokenProvider>() {
+        internal class OAuth2TokenProviderDeserializer : ValueDeserializer<OAuth2TokenProvider>() {
             data class ProviderConfig(
                 val keyProvider: KeyProviderConfig?,
                 val systemTime: String?,
@@ -48,14 +48,14 @@ data class OAuth2Config
 
             override fun deserialize(
                 p: JsonParser,
-                ctxt: DeserializationContext?,
+                ctxt: DeserializationContext,
             ): OAuth2TokenProvider {
                 val node: JsonNode = p.readValueAsTree()
                 val config: ProviderConfig =
                     if (!node.isObject) {
                         return OAuth2TokenProvider()
                     } else {
-                        p.codec.treeToValue(node, ProviderConfig::class.java)
+                        ctxt.readTreeAsValue(node, ProviderConfig::class.java)
                     }
                 val jwks =
                     config.keyProvider?.initialKeys?.let {
@@ -77,7 +77,7 @@ data class OAuth2Config
             }
         }
 
-        class OAuth2HttpServerDeserializer : JsonDeserializer<OAuth2HttpServer>() {
+        internal class OAuth2HttpServerDeserializer : ValueDeserializer<OAuth2HttpServer>() {
             enum class ServerType {
                 MockWebServerWrapper,
                 NettyWrapper,
@@ -106,9 +106,9 @@ data class OAuth2Config
                 val node: JsonNode = p.readValueAsTree()
                 val serverConfig: ServerConfig =
                     if (node.isObject) {
-                        p.codec.treeToValue(node, ServerConfig::class.java)
+                        ctxt.readTreeAsValue(node, ServerConfig::class.java)
                     } else {
-                        ServerConfig(ServerType.valueOf(node.textValue()))
+                        ServerConfig(ServerType.valueOf(node.asString()))
                     }
                 val ssl: Ssl? = serverConfig.ssl?.ssl()
                 return when (serverConfig.type) {

--- a/src/main/kotlin/no/nav/security/mock/oauth2/debugger/SessionManager.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/debugger/SessionManager.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2.debugger
 
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.EncryptionMethod
 import com.nimbusds.jose.JWEAlgorithm
 import com.nimbusds.jose.JWEHeader
@@ -11,6 +10,7 @@ import com.nimbusds.jose.crypto.DirectEncrypter
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.http.OAuth2HttpRequest
 import no.nav.security.mock.oauth2.http.objectMapper
+import tools.jackson.module.kotlin.readValue
 import javax.crypto.KeyGenerator
 import javax.crypto.SecretKey
 

--- a/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandler.kt
@@ -1,9 +1,5 @@
 package no.nav.security.mock.oauth2.grant
 
-import com.fasterxml.jackson.core.JsonProcessingException
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.AuthorizationCode
 import com.nimbusds.oauth2.sdk.OAuth2Error
@@ -22,6 +18,10 @@ import no.nav.security.mock.oauth2.token.OAuth2TokenCallback
 import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import no.nav.security.mock.oauth2.token.RequestMappingTokenCallback
 import okhttp3.HttpUrl
+import tools.jackson.core.JacksonException
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.util.concurrent.ConcurrentHashMap
 import kotlin.collections.set
 
@@ -159,7 +159,7 @@ internal class AuthorizationCodeHandler(
                             .forEach { field ->
                                 putIfAbsent(field.key, jsonMapper.readValue(field.value.toString()))
                             }
-                    } catch (exception: JsonProcessingException) {
+                    } catch (exception: JacksonException) {
                         log.warn("claims value $it could not be processed as JSON, details: ${exception.message}")
                     }
                 }

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpResponse.kt
@@ -2,9 +2,6 @@ package no.nav.security.mock.oauth2.http
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.oauth2.sdk.ErrorObject
 import com.nimbusds.oauth2.sdk.ResponseMode
 import com.nimbusds.openid.connect.sdk.AuthenticationSuccessResponse
@@ -12,8 +9,11 @@ import io.netty.handler.codec.http.HttpHeaderNames
 import no.nav.security.mock.oauth2.templates.TemplateMapper
 import no.nav.security.mock.oauth2.token.KeyGenerator
 import okhttp3.Headers
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.module.kotlin.jacksonObjectMapper
 
-val objectMapper: ObjectMapper = jacksonObjectMapper()
+internal val objectMapper: ObjectMapper = jacksonObjectMapper()
+private val prettyWriter = objectMapper.writerWithDefaultPrettyPrinter()
 val templateMapper: TemplateMapper = TemplateMapper.create {}
 
 data class OAuth2HttpResponse(
@@ -111,9 +111,7 @@ fun json(anyObject: Any): OAuth2HttpResponse =
                 }
 
                 else -> {
-                    objectMapper
-                        .enable(SerializationFeature.INDENT_OUTPUT)
-                        .writeValueAsString(anyObject)
+                    prettyWriter.writeValueAsString(anyObject)
                 }
             },
     )
@@ -179,8 +177,7 @@ fun oauth2Error(error: ErrorObject): OAuth2HttpResponse {
             ),
         status = responseCode,
         body =
-            objectMapper
-                .enable(SerializationFeature.INDENT_OUTPUT)
+            prettyWriter
                 .writeValueAsString(error.toJSONObject())
                 .lowercase(),
     )

--- a/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/OAuth2ConfigTest.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2
 
-import com.fasterxml.jackson.databind.JsonMappingException
 import com.nimbusds.jose.jwk.KeyType
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.Matcher
@@ -25,6 +24,7 @@ import no.nav.security.mock.oauth2.http.MockWebServerWrapper
 import no.nav.security.mock.oauth2.http.NettyWrapper
 import org.intellij.lang.annotations.Language
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.DatabindException
 import java.io.File
 import java.security.KeyStore
 import java.security.cert.X509Certificate
@@ -37,7 +37,7 @@ internal class OAuth2ConfigTest {
     fun `create httpServer from json`() {
         OAuth2Config.fromJson(withNettyHttpServer).httpServer should beInstanceOf<NettyWrapper>()
         OAuth2Config.fromJson(withMockWebServerWrapper).httpServer should beInstanceOf<MockWebServerWrapper>()
-        shouldThrow<JsonMappingException> {
+        shouldThrow<DatabindException> {
             OAuth2Config.fromJson(withUnknownHttpServer)
         }
     }
@@ -79,7 +79,7 @@ internal class OAuth2ConfigTest {
 
     @Test
     fun `create config from json with an unsupported algorithm should throw Oauth2Exception`() {
-        shouldThrow<JsonMappingException> {
+        shouldThrow<DatabindException> {
             OAuth2Config.fromJson(signingJsonUnsupported)
         }.message shouldContain "Unsupported algorithm: EdDSA"
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2ServerKtTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/StandaloneMockOAuth2ServerKtTest.kt
@@ -1,7 +1,5 @@
 package no.nav.security.mock.oauth2
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
@@ -15,6 +13,8 @@ import no.nav.security.mock.oauth2.StandaloneConfig.oauth2Config
 import no.nav.security.mock.oauth2.StandaloneConfig.port
 import no.nav.security.mock.oauth2.http.NettyWrapper
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.io.File
 
 internal class StandaloneMockOAuth2ServerKtTest {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/InteractiveLoginIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/InteractiveLoginIntegrationTest.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2.e2e
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.asClue
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -23,6 +22,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.util.stream.Stream
 
 class InteractiveLoginIntegrationTest {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/WellKnownIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/WellKnownIntegrationTest.kt
@@ -1,7 +1,5 @@
 package no.nav.security.mock.oauth2.e2e
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import io.kotest.assertions.asClue
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -10,6 +8,8 @@ import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
 import no.nav.security.mock.oauth2.withMockOAuth2Server
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 
 class WellKnownIntegrationTest {
     private val client = client()

--- a/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/grant/AuthorizationCodeHandlerTest.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2.grant
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.nimbusds.jwt.PlainJWT
 import com.nimbusds.jwt.SignedJWT
 import com.nimbusds.oauth2.sdk.ResponseMode
@@ -23,6 +22,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.util.stream.Stream
 
 internal class AuthorizationCodeHandlerTest {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/introspect/IntrospectTest.kt
@@ -1,7 +1,5 @@
 package no.nav.security.mock.oauth2.introspect
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.JWSAlgorithm
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
@@ -19,6 +17,8 @@ import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Http.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Http.kt
@@ -1,7 +1,5 @@
 package no.nav.security.mock.oauth2.testutils
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.security.mock.oauth2.extensions.keyValuesToMap
 import okhttp3.Credentials
 import okhttp3.FormBody
@@ -10,6 +8,8 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.net.URLEncoder
 import java.security.KeyStore
 import javax.net.ssl.SSLContext

--- a/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Token.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/testutils/Token.kt
@@ -1,7 +1,5 @@
 package no.nav.security.mock.oauth2.testutils
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
@@ -36,6 +34,8 @@ import no.nav.security.mock.oauth2.token.DefaultOAuth2TokenCallback
 import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.HttpUrl.Companion.toHttpUrl
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.security.KeyPairGenerator
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey

--- a/src/test/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfoTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/userinfo/UserInfoTest.kt
@@ -1,7 +1,5 @@
 package no.nav.security.mock.oauth2.userinfo
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jose.JWSAlgorithm
 import io.kotest.assertions.asClue
 import io.kotest.assertions.throwables.shouldThrow
@@ -17,6 +15,8 @@ import no.nav.security.mock.oauth2.token.OAuth2TokenProvider
 import okhttp3.Headers
 import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.jupiter.api.Test
+import tools.jackson.module.kotlin.jacksonObjectMapper
+import tools.jackson.module.kotlin.readValue
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 


### PR DESCRIPTION
Jackson 3 uses the `tools.jackson` group id and package and still depends on
`jackson-annotations` 2.x, so it coexists with Jackson 2 instead of replacing it.
Consumers on Jackson 2 get no version conflict. The Ktor and Spring Boot example
apps in `src/test` stay on Jackson 2 and exercise that combination.

Mappers are immutable in Jackson 3, which also fixes `json()` and `oauth2Error()`
mutating the shared mapper on every call.

Also adds the 6.0.0 migration guide, covering the breaking changes accumulated on
master since 5.0.2: logback and kotlinx-serialization no longer bundled (#998), the
debugger no longer targeting external identity providers (#1000), and the Netty
request body cap (#1001).

## Breaking changes

- `no.nav.security.mock.oauth2.http.objectMapper` and the deserializers nested in
  `OAuth2Config` are now `internal`, so the library no longer exposes Jackson types
  in its Kotlin API. Construct your own mapper if you used `objectMapper`.