### PR TITLE
fix: raise published kotlin-stdlib floor to 2.2.21

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -38,6 +38,16 @@ The library now uses Jackson 3 (`tools.jackson.*`) instead of Jackson 2 (`com.fa
 
 **Migration:** these are now `internal`, so the library no longer exposes Jackson types in its Kotlin API. Construct your own mapper if you used `objectMapper`.
 
+### Kotlin 2.2.21 is the minimum runtime
+
+Jackson 3 brought in `jackson-module-kotlin` 3.x, which references `kotlin.time.Instant`. That class arrived in `kotlin-stdlib` 2.1.20. Releases 6.0.0 and 6.0.1 still declared `kotlin-stdlib` 1.9.0, so consumers who took that version could fail with `NoClassDefFoundError: kotlin/time/Instant`.
+
+**New behavior (6.0.2):** the published `kotlin-stdlib` and `kotlin-reflect` version is 2.2.21, matching what okhttp already asks for.
+
+**Affected pattern:** none directly. Kotlin consumers already needed a 2.0 compiler for 6.x, and the stdlib is backwards compatible.
+
+**Migration:** upgrade to 6.0.2. Nothing else, unless you pinned `kotlin-stdlib` below 2.2.21 yourself — raise it.
+
 ### `NettyWrapper` caps request bodies at 1 MiB
 
 Request bodies were aggregated with no limit, so any unauthenticated client could exhaust the heap by sending a large body to any endpoint.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,6 @@ val bouncyCastleVersion = "1.85"
 val springBootVersion = "3.5.14"
 val reactorTestVersion = "3.8.6"
 val ktorVersion = "3.5.1"
-val jsonPathVersion = "2.9.0"
 
 val mainClassKt = "no.nav.security.mock.oauth2.StandaloneMockOAuth2ServerKt"
 
@@ -35,6 +34,7 @@ plugins {
     id("com.google.cloud.tools.jib") version "3.5.4"
     id("com.vanniktech.maven.publish") version "0.37.0"
     id("org.jetbrains.dokka") version "2.2.0"
+    id("io.github.usefulness.maven-sympathy") version "0.3.0"
     alias(libs.plugins.kotlin.serialization)
     `java-library`
     signing
@@ -52,8 +52,17 @@ java {
 kotlin {
     val kotlinTarget = libs.versions.kotlinTarget
     val kotlinLanguage = libs.versions.kotlinLanguage
+    val kotlinToolchain = libs.versions.kotlinToolchain
     val kotlinLanguageVersion = kotlinLanguage.map {
         KotlinVersion.fromVersion(it.toKotlinMinor())
+    }
+
+    // Consumers must be able to compile against what we publish, and we must be able to build it.
+    require(kotlinLanguage.get().toVersionRank() <= kotlinTarget.get().toVersionRank()) {
+        "kotlinLanguage (${kotlinLanguage.get()}) must not exceed kotlinTarget (${kotlinTarget.get()})"
+    }
+    require(kotlinTarget.get().toVersionRank() <= kotlinToolchain.get().toVersionRank()) {
+        "kotlinTarget (${kotlinTarget.get()}) must not exceed kotlinToolchain (${kotlinToolchain.get()})"
     }
 
     compilerOptions {
@@ -72,6 +81,10 @@ kotlin {
 // 1.7.21 => 1.7, 1.9 => 1.9
 fun String.toKotlinMinor() = split(".").take(2).joinToString(".")
 
+// 2.1.21 => 2001021, orders versions with unequal part counts
+fun String.toVersionRank() =
+    (split(".").map { it.toInt() } + listOf(0, 0)).take(3).fold(0) { rank, part -> rank * 1000 + part }
+
 apply(plugin = "org.jmailen.kotlinter")
 
 repositories {
@@ -84,6 +97,29 @@ repositories {
 val standaloneRuntime = configurations.dependencyScope("standaloneRuntime")
 configurations.runtimeClasspath {
     extendsFrom(standaloneRuntime.get())
+}
+
+// Smoke test on the kotlin-stdlib version we publish, which the normal test suite never uses.
+// Keep it on plain JUnit: Kotest, Spring and Ktor have Kotlin floors of their own.
+val minStdlibTest = testing.suites.register<JvmTestSuite>("minStdlibTest") {
+    useJUnitJupiter(junitJupiterVersion)
+    dependencies {
+        // Depend on the project the way a consumer does, so we get the versions we publish
+        implementation(project())
+        runtimeOnly("ch.qos.logback:logback-classic:$logbackVersion")
+    }
+}
+
+configurations.named("minStdlibTestRuntimeClasspath") {
+    val floor = libs.versions.kotlinTarget.get()
+    resolutionStrategy.force(
+        "org.jetbrains.kotlin:kotlin-stdlib:$floor",
+        "org.jetbrains.kotlin:kotlin-reflect:$floor",
+    )
+}
+
+tasks.check {
+    dependsOn(minStdlibTest)
 }
 
 dependencies {
@@ -113,33 +149,10 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server:$springBootVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-oauth2-client:$springBootVersion")
     testImplementation("org.springframework.boot:spring-boot-starter-test:$springBootVersion")
-    constraints {
-        testImplementation("com.jayway.jsonpath:json-path") {
-            version {
-                require(jsonPathVersion)
-            }
-        }
-    }
     testImplementation("org.springframework.boot:spring-boot-test:$springBootVersion")
     constraints {
-        testImplementation("org.xmlunit:xmlunit-core") {
-            because("previous versions have security vulnerabilities")
-            version {
-                require("2.10.0")
-            }
-        }
         testImplementation("org.yaml:snakeyaml:2.6") {
             because("previous versions have security vulnerabilities")
-        }
-        add("api", "com.squareup.okio:okio") {
-            version {
-                require("3.4.0")
-            }
-        }
-        add("testImplementation", "com.google.guava:guava") {
-            version {
-                require("32.1.2-jre")
-            }
         }
     }
     testImplementation("io.projectreactor:reactor-test:$reactorTestVersion")
@@ -163,6 +176,7 @@ configurations {
     all {
         resolutionStrategy.force(
             "com.fasterxml.woodstox:woodstox-core:7.2.1",
+            // Netty pins epoll a patch behind netty-codec-http. Keep them on the same version.
             "io.netty:netty-transport-native-epoll:$nettyVersion",
         )
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,8 @@
 [versions]
-kotlinTarget = "1.9.0" # Minimum supported Kotlin version for consumers of the library
-kotlinLanguage = "2.0" # Language level used by compiler (Kotlin 2.4 no longer supports 1.9 language mode)
-kotlinToolchain = "2.4.10" # Actual version used by tooling within this project
+# Keep kotlinLanguage <= kotlinTarget <= kotlinToolchain.
+kotlinLanguage = "2.0" # Language and API level we compile at, so the oldest compiler consumers can use
+kotlinTarget = "2.2.21" # kotlin-stdlib we publish in the POM. Must not be below the stdlib any api dependency declares, currently okhttp. Verified by minStdlibTest
+kotlinToolchain = "2.4.10" # Compiler this project builds with. Not visible to consumers
 
 [plugins]
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinToolchain" }

--- a/src/minStdlibTest/kotlin/no/nav/security/mock/oauth2/MinimumStdlibSmokeTest.kt
+++ b/src/minStdlibTest/kotlin/no/nav/security/mock/oauth2/MinimumStdlibSmokeTest.kt
@@ -1,0 +1,72 @@
+package no.nav.security.mock.oauth2
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.time.Duration
+
+// Runs on the kotlin-stdlib version declared for consumers. Every endpoint here serializes JSON,
+// where a stdlib too old for our Kotlin-compiled dependencies fails.
+// A missing stdlib class kills the handler thread, not this one, so the calls need timeouts.
+class MinimumStdlibSmokeTest {
+    @Test
+    @Timeout(30)
+    fun `server serves metadata and issues a token on the declared kotlin-stdlib`() {
+        val server = MockOAuth2Server()
+        server.start()
+        try {
+            val client = HttpClient.newBuilder().connectTimeout(REQUEST_TIMEOUT).build()
+
+            val wellKnown = client.get(server.wellKnownUrl("default").toString())
+            assertEquals(200, wellKnown.statusCode())
+            assertTrue(wellKnown.body().contains("token_endpoint"))
+
+            val jwks = client.get(server.jwksUrl("default").toString())
+            assertEquals(200, jwks.statusCode())
+            assertTrue(jwks.body().contains("keys"))
+
+            val token =
+                client.post(
+                    server.tokenEndpointUrl("default").toString(),
+                    "grant_type=client_credentials&client_id=client&client_secret=secret&scope=scope",
+                )
+            assertEquals(200, token.statusCode())
+            assertTrue(token.body().contains("access_token"))
+        } finally {
+            server.shutdown()
+        }
+    }
+
+    private fun HttpClient.get(url: String): HttpResponse<String> =
+        send(
+            HttpRequest
+                .newBuilder(URI.create(url))
+                .timeout(REQUEST_TIMEOUT)
+                .GET()
+                .build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private fun HttpClient.post(
+        url: String,
+        form: String,
+    ): HttpResponse<String> =
+        send(
+            HttpRequest
+                .newBuilder(URI.create(url))
+                .timeout(REQUEST_TIMEOUT)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(form))
+                .build(),
+            HttpResponse.BodyHandlers.ofString(),
+        )
+
+    private companion object {
+        val REQUEST_TIMEOUT: Duration = Duration.ofSeconds(10)
+    }
+}


### PR DESCRIPTION
`jackson-module-kotlin` 3.2.0 calls `kotlin.time.Instant`, added in stdlib 2.1.20. We published a 1.9.0 floor, so Maven consumers hit `NoClassDefFoundError` on the first JSON response. Gradle builds resolve to the newest version in the graph, which is why this reached a release.

Added guards to prevent this from happening again:

- `maven-sympathy` fails when a declared version is upgraded by the graph.
- `minStdlibTest` smoke-tests the stdlib we publish, covering what sympathy cannot see as `jackson-module-kotlin` declares stdlib as `provided`.

Also drop the `okio`, `json-path`, `xmlunit-core` and `guava` constraints, all now resolve above their floor.

Fixes #1009