### PR TITLE
fix: migrate from Jackson 2 to Jackson 3 in example applications

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,7 +32,7 @@ If you construct `DebuggerRequestHandler` yourself, it now takes an `OAuth2HttpS
 
 The library now uses Jackson 3 (`tools.jackson.*`) instead of Jackson 2 (`com.fasterxml.jackson.*`).
 
-**Consumers on Jackson 2 are unaffected.** Jackson 3 uses a different group ID and package, and still depends on `com.fasterxml.jackson.core:jackson-annotations:2.x`, so both can be on the classpath at once. The Ktor and Spring Boot example apps in this project's test suite stay on Jackson 2 and exercise that combination.
+**Consumers on Jackson 2 are unaffected.** Jackson 3 uses a different group ID and package, and still depends on `com.fasterxml.jackson.core:jackson-annotations:2.x`. Imports from `com.fasterxml.jackson.annotation.*` (for example `@JsonProperty` and `@JsonInclude`) are still correct and expected with Jackson 3.
 
 **Affected pattern:** using the `no.nav.security.mock.oauth2.http.objectMapper` top-level property, or the `OAuth2TokenProviderDeserializer` and `OAuth2HttpServerDeserializer` classes nested in `OAuth2Config`.
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,11 +9,6 @@ val logbackVersion = "1.6.0"
 val nimbusSdkVersion = "11.38.2"
 val mockWebServerVersion = "5.4.0"
 val jacksonVersion = "3.2.1"
-
-// Ktor and Spring Boot are Jackson 2 only, so the example apps in src/test pull it in
-// alongside the Jackson 3 used by the library itself. Their BOMs lag behind, so pin the
-// floor here rather than inheriting whatever they happen to resolve to.
-val jackson2TestVersion = "2.22.1"
 val nettyVersion = "4.2.17.Final"
 val junitJupiterVersion = "6.1.2"
 val freemarkerVersion = "2.3.34"
@@ -135,9 +130,6 @@ dependencies {
     implementation("io.github.microutils:kotlin-logging:$kotlinLoggingVersion")
     implementation("org.freemarker:freemarker:$freemarkerVersion")
     implementation("org.bouncycastle:bcpkix-jdk18on:$bouncyCastleVersion")
-    testImplementation(platform("com.fasterxml.jackson:jackson-bom:$jackson2TestVersion"))
-    testImplementation("com.fasterxml.jackson.core:jackson-databind")
-    testImplementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     testImplementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.11.0")
     testImplementation("org.assertj:assertj-core:$assertjVersion")
     testImplementation("org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion")
@@ -166,7 +158,7 @@ dependencies {
     testImplementation("io.ktor:ktor-server-content-negotiation:$ktorVersion")
     testImplementation("io.ktor:ktor-client-core:$ktorVersion")
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
-    testImplementation("io.ktor:ktor-serialization-jackson:$ktorVersion")
+    testImplementation("io.ktor:ktor-serialization-jackson3:$ktorVersion")
     testImplementation("io.ktor:ktor-client-cio:$ktorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion"){
         //Provides transitive vulnerable dependency maven:commons-codec:commons-codec:1.11 WS-2019-0379 6.5 Input Validation  Results powered by Mend.io

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ val junitJupiterVersion = "6.1.2"
 val freemarkerVersion = "2.3.34"
 val kotestVersion = "6.2.3"
 val bouncyCastleVersion = "1.85"
-val springBootVersion = "3.5.14"
+val springBootVersion = "4.1.0"
 val reactorTestVersion = "3.8.6"
 val ktorVersion = "3.5.1"
 

--- a/src/test/kotlin/examples/kotlin/ktor/client/OAuth2Client.kt
+++ b/src/test/kotlin/examples/kotlin/ktor/client/OAuth2Client.kt
@@ -4,7 +4,6 @@ import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -13,7 +12,8 @@ import io.ktor.client.request.header
 import io.ktor.http.Headers
 import io.ktor.http.Parameters
 import io.ktor.http.headersOf
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
+import tools.jackson.databind.DeserializationFeature
 import java.nio.charset.StandardCharsets
 import java.security.KeyPair
 import java.security.interfaces.RSAPrivateKey
@@ -29,7 +29,9 @@ val httpClient =
         install(ContentNegotiation) {
             jackson {
                 configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+                changeDefaultPropertyInclusion { inclusion ->
+                    inclusion.withValueInclusion(JsonInclude.Include.NON_NULL)
+                }
             }
         }
     }

--- a/src/test/kotlin/examples/kotlin/ktor/login/OAuth2LoginApp.kt
+++ b/src/test/kotlin/examples/kotlin/ktor/login/OAuth2LoginApp.kt
@@ -2,7 +2,6 @@ package examples.kotlin.ktor.login
 
 import com.auth0.jwt.JWT
 import com.fasterxml.jackson.annotation.JsonInclude
-import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -11,7 +10,7 @@ import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.encodedPath
 import io.ktor.resources.Resource
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.application.Application
 import io.ktor.server.application.ApplicationCall
 import io.ktor.server.application.install
@@ -32,6 +31,7 @@ import io.ktor.server.routing.param
 import io.ktor.server.routing.routing
 import io.ktor.server.util.url
 import kotlinx.serialization.Serializable
+import tools.jackson.databind.DeserializationFeature
 
 fun main() {
     embeddedServer(Netty, port = 8080) {
@@ -141,7 +141,9 @@ internal val httpClient =
         install(ContentNegotiation) {
             jackson {
                 configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+                changeDefaultPropertyInclusion { inclusion ->
+                    inclusion.withValueInclusion(JsonInclude.Include.NON_NULL)
+                }
             }
         }
     }

--- a/src/test/kotlin/examples/kotlin/ktor/resourceserver/OAuth2ResourceServerApp.kt
+++ b/src/test/kotlin/examples/kotlin/ktor/resourceserver/OAuth2ResourceServerApp.kt
@@ -4,14 +4,12 @@ import com.auth0.jwk.JwkProviderBuilder
 import com.auth0.jwt.interfaces.Payload
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.fasterxml.jackson.databind.DeserializationFeature
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.request.prepareGet
-import io.ktor.serialization.jackson.jackson
+import io.ktor.serialization.jackson3.jackson
 import io.ktor.server.application.Application
-import io.ktor.server.application.call
 import io.ktor.server.application.install
 import io.ktor.server.auth.Authentication
 import io.ktor.server.auth.authenticate
@@ -26,6 +24,7 @@ import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
 import kotlinx.coroutines.runBlocking
 import mu.KotlinLogging
+import tools.jackson.databind.DeserializationFeature
 import java.net.URI
 import java.util.concurrent.TimeUnit
 
@@ -106,7 +105,9 @@ class AuthConfig(
                 install(ContentNegotiation) {
                     jackson {
                         configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
-                        setDefaultPropertyInclusion(JsonInclude.Include.NON_NULL)
+                        changeDefaultPropertyInclusion { inclusion ->
+                            inclusion.withValueInclusion(JsonInclude.Include.NON_NULL)
+                        }
                     }
                 }
             }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/AbstractExampleApp.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/AbstractExampleApp.kt
@@ -1,6 +1,5 @@
 package no.nav.security.mock.oauth2.examples
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.jwk.JWKSet
@@ -24,6 +23,7 @@ import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
+import tools.jackson.module.kotlin.jacksonObjectMapper
 import java.net.URI
 import java.util.HashSet
 
@@ -32,6 +32,8 @@ private val log = KotlinLogging.logger {}
 abstract class AbstractExampleApp(
     oauth2DiscoveryUrl: String,
 ) {
+    protected val jacksonObjectMapper = jacksonObjectMapper()
+
     val oauth2Client: OkHttpClient =
         OkHttpClient()
             .newBuilder()
@@ -119,7 +121,7 @@ abstract class AbstractExampleApp(
         MockResponse()
             .setResponseCode(200)
             .setHeader("Content-Type", "application/json")
-            .setBody(ObjectMapper().writeValueAsString(value))
+            .setBody(jacksonObjectMapper.writeValueAsString(value))
 
     abstract fun handleRequest(request: RecordedRequest): MockResponse
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/clientcredentials/ExampleAppWithClientCredentialsClient.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/clientcredentials/ExampleAppWithClientCredentialsClient.kt
@@ -39,7 +39,7 @@ class ExampleAppWithClientCredentialsClient(
                         ).build(),
                 ).execute()
         return tokenResponse.body.string().let {
-            jacksonObjectMapper.readValue<Map<String, String?>>(it)["access_token"]
+            jacksonObjectMapper.readValue<no.nav.security.mock.oauth2.http.OAuth2TokenResponse>(it).accessToken
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/clientcredentials/ExampleAppWithClientCredentialsClient.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/clientcredentials/ExampleAppWithClientCredentialsClient.kt
@@ -1,8 +1,5 @@
 package no.nav.security.mock.oauth2.examples.clientcredentials
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import no.nav.security.mock.oauth2.examples.AbstractExampleApp
 import okhttp3.Credentials
 import okhttp3.FormBody
@@ -10,6 +7,7 @@ import okhttp3.Request
 import okhttp3.Response
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
+import tools.jackson.module.kotlin.readValue
 
 class ExampleAppWithClientCredentialsClient(
     oauth2DiscoveryUrl: String,
@@ -41,7 +39,7 @@ class ExampleAppWithClientCredentialsClient(
                         ).build(),
                 ).execute()
         return tokenResponse.body.string().let {
-            ObjectMapper().readValue<JsonNode>(it).get("access_token")?.textValue()
+            jacksonObjectMapper.readValue<Map<String, String?>>(it)["access_token"]
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/clientcredentials/ExampleAppWithClientCredentialsClient.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/clientcredentials/ExampleAppWithClientCredentialsClient.kt
@@ -1,6 +1,7 @@
 package no.nav.security.mock.oauth2.examples.clientcredentials
 
 import no.nav.security.mock.oauth2.examples.AbstractExampleApp
+import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
 import okhttp3.Credentials
 import okhttp3.FormBody
 import okhttp3.Request
@@ -39,7 +40,7 @@ class ExampleAppWithClientCredentialsClient(
                         ).build(),
                 ).execute()
         return tokenResponse.body.string().let {
-            jacksonObjectMapper.readValue<no.nav.security.mock.oauth2.http.OAuth2TokenResponse>(it).accessToken
+            jacksonObjectMapper.readValue<OAuth2TokenResponse>(it).accessToken
         }
     }
 }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
@@ -42,7 +42,7 @@ class ExampleAppWithOpenIdConnect(
                                         .build(),
                                 ).build(),
                         ).execute()
-                val idToken: String = jacksonObjectMapper.readValue<Map<String, String>>(tokenResponse.body.string()).getValue("id_token")
+                val idToken: String = jacksonObjectMapper.readValue<no.nav.security.mock.oauth2.http.OAuth2TokenResponse>(tokenResponse.body.string()).idToken ?: error("missing id_token in token response")
                 val idTokenClaims: JWTClaimsSet = verifyJwt(idToken, metadata.issuer, retrieveJwks())
                 MockResponse()
                     .setResponseCode(200)

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
@@ -4,6 +4,7 @@ import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import mu.KotlinLogging
 import no.nav.security.mock.oauth2.examples.AbstractExampleApp
+import no.nav.security.mock.oauth2.http.OAuth2TokenResponse
 import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
@@ -42,7 +43,8 @@ class ExampleAppWithOpenIdConnect(
                                         .build(),
                                 ).build(),
                         ).execute()
-                val idToken: String = jacksonObjectMapper.readValue<no.nav.security.mock.oauth2.http.OAuth2TokenResponse>(tokenResponse.body.string()).idToken ?: error("missing id_token in token response")
+                val idToken: String =
+                    jacksonObjectMapper.readValue<OAuth2TokenResponse>(tokenResponse.body.string()).idToken ?: error("missing id_token in token response")
                 val idTokenClaims: JWTClaimsSet = verifyJwt(idToken, metadata.issuer, retrieveJwks())
                 MockResponse()
                     .setResponseCode(200)

--- a/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/examples/openidconnect/ExampleAppWithOpenIdConnect.kt
@@ -1,8 +1,5 @@
 package no.nav.security.mock.oauth2.examples.openidconnect
 
-import com.fasterxml.jackson.databind.JsonNode
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.module.kotlin.readValue
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.openid.connect.sdk.AuthenticationRequest
 import mu.KotlinLogging
@@ -11,6 +8,7 @@ import okhttp3.FormBody
 import okhttp3.Request
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
+import tools.jackson.module.kotlin.readValue
 
 private val log = KotlinLogging.logger {}
 
@@ -44,7 +42,7 @@ class ExampleAppWithOpenIdConnect(
                                         .build(),
                                 ).build(),
                         ).execute()
-                val idToken: String = ObjectMapper().readValue<JsonNode>(tokenResponse.body.string()).get("id_token").textValue()
+                val idToken: String = jacksonObjectMapper.readValue<Map<String, String>>(tokenResponse.body.string()).getValue("id_token")
                 val idTokenClaims: JWTClaimsSet = verifyJwt(idToken, metadata.issuer, retrieveJwks())
                 MockResponse()
                     .setResponseCode(200)


### PR DESCRIPTION
This pull request updates the example applications and documentation to use Jackson 3 instead of Jackson 2, and ensures compatibility with the new package structure and API changes. The main changes include updating imports, adjusting configuration code for Jackson 3, and clarifying documentation about annotation compatibility.

**Migration to Jackson 3 and Code Adjustments:**

* Updated all example apps (`OAuth2Client.kt`, `OAuth2LoginApp.kt`, `OAuth2ResourceServerApp.kt`, and related classes) to use `tools.jackson.*` imports and `io.ktor.serialization.jackson3.jackson` for Jackson 3 compatibility, replacing previous Jackson 2 imports. [[1]](diffhunk://#diff-41d4d64e59b76960f3342b8a21cd00c26fb0dd03dee7a352e522005635ee281cL16-R16) [[2]](diffhunk://#diff-41d6ee93c89c7d736e1be57597bcb1eb0cbaac6e017abf5b6d4d7164d1a90e97L14-R13) [[3]](diffhunk://#diff-048a4a9ad161ca3ee1c1b35ffa238390c0295ce7113d4fd875ac492c219e987bL7-L14) [[4]](diffhunk://#diff-048a4a9ad161ca3ee1c1b35ffa238390c0295ce7113d4fd875ac492c219e987bR27)
* Replaced deprecated Jackson 2 configuration methods with Jackson 3 equivalents, such as using `changeDefaultPropertyInclusion` instead of `setDefaultPropertyInclusion` in Ktor content negotiation setup. [[1]](diffhunk://#diff-41d4d64e59b76960f3342b8a21cd00c26fb0dd03dee7a352e522005635ee281cL32-R34) [[2]](diffhunk://#diff-41d6ee93c89c7d736e1be57597bcb1eb0cbaac6e017abf5b6d4d7164d1a90e97L144-R146) [[3]](diffhunk://#diff-048a4a9ad161ca3ee1c1b35ffa238390c0295ce7113d4fd875ac492c219e987bL109-R110)

**Refactoring Example App Serialization:**

* Updated example app base classes and OAuth2 example clients to use the Jackson 3 Kotlin module (`tools.jackson.module.kotlin.jacksonObjectMapper` and `readValue`) for JSON serialization and deserialization, eliminating direct use of `ObjectMapper` and `JsonNode` from Jackson 2. [[1]](diffhunk://#diff-5f8ecf1da33ff667d866087a0a97d4abda992bf05fae53fe34270ec8646d6d1aR26) [[2]](diffhunk://#diff-5f8ecf1da33ff667d866087a0a97d4abda992bf05fae53fe34270ec8646d6d1aR35-R36) [[3]](diffhunk://#diff-5f8ecf1da33ff667d866087a0a97d4abda992bf05fae53fe34270ec8646d6d1aL122-R124) [[4]](diffhunk://#diff-e742f529a0aa6134c7e5e51db308696b6ab1b849a3b6d6b701ac74f3da79357fL3-R10) [[5]](diffhunk://#diff-e742f529a0aa6134c7e5e51db308696b6ab1b849a3b6d6b701ac74f3da79357fL44-R42) [[6]](diffhunk://#diff-c564a9b2a7b3426c6f3aeb05c5132979eb1e2eb3a887b42a31fd5415588664c2L3-L5) [[7]](diffhunk://#diff-c564a9b2a7b3426c6f3aeb05c5132979eb1e2eb3a887b42a31fd5415588664c2R11) [[8]](diffhunk://#diff-c564a9b2a7b3426c6f3aeb05c5132979eb1e2eb3a887b42a31fd5415588664c2L47-R45)

**Documentation Update:**

* Clarified in `MIGRATION.md` that annotation imports from `com.fasterxml.jackson.annotation.*` remain valid and expected with Jackson 3, improving guidance for consumers during migration.