### PR TITLE
fix: enhance IPv6 host header handling in OAuth2 requests

### DIFF
--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -19,6 +19,7 @@ import no.nav.security.mock.oauth2.extensions.toUserInfoUrl
 import no.nav.security.mock.oauth2.missingParameter
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import java.net.URI
 
 data class OAuth2HttpRequest(
     val headers: Headers,
@@ -121,15 +122,7 @@ data class OAuth2HttpRequest(
         }
     }
 
-    private fun parseHostHeader(): Pair<String, Int>? {
-        val hostHeader = this.headers["host"]
-        if (hostHeader != null) {
-            val hostPort = hostHeader.split(":")
-            val port = if (hostPort.size == 2) hostPort[1].toInt() else -1
-            return hostPort[0] to port
-        }
-        return null
-    }
+    private fun parseHostHeader(): Pair<String, Int>? = hostAndPortFromHostHeader(this.headers["host"])
 
     data class Parameters(
         val parameterString: String?,
@@ -139,3 +132,34 @@ data class OAuth2HttpRequest(
         fun get(name: String): String? = map[name]
     }
 }
+
+/**
+ * Splits an HTTP `Host` header (RFC 9110 §7.2) into its host and port components.
+ *
+ * Returns `null` for a missing, blank or unparseable header. The port is `-1` when the header
+ * carries none or an out-of-range one - the "no explicit port" sentinel the callers expect;
+ * it is never a value okhttp's `HttpUrl.Builder.port` would reject.
+ *
+ * Bracketed IPv6 literals (`[::1]`, `[::1]:8080`) are delegated to [URI], which knows the
+ * `[...]` grammar; anything [URI] rejects or does not treat as a server-based authority
+ * (e.g. registry-style names with underscores) falls back to a plain colon split so
+ * previously working Host headers keep working.
+ */
+internal fun hostAndPortFromHostHeader(hostHeader: String?): Pair<String, Int>? {
+    val header = hostHeader?.takeIf { it.isNotBlank() } ?: return null
+
+    runCatching { URI("//$header") }.getOrNull()?.let { uri ->
+        if (uri.host != null) return uri.host to uri.port.asHostHeaderPort()
+    }
+
+    // URI could not parse it. A bracketed literal it rejected (unclosed bracket,
+    // non-numeric port, ...) is not something the colon split can salvage either.
+    if (header.startsWith("[")) return null
+
+    val hostPort = header.split(":")
+    val port = if (hostPort.size == 2) hostPort[1].toIntOrNull()?.asHostHeaderPort() ?: -1 else -1
+    return hostPort[0] to port
+}
+
+/** A port is only meaningful when it is a real TCP port; anything else becomes the `-1` sentinel. */
+private fun Int.asHostHeaderPort(): Int = if (this in 1..65535) this else -1

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt
@@ -134,16 +134,9 @@ data class OAuth2HttpRequest(
 }
 
 /**
- * Splits an HTTP `Host` header (RFC 9110 §7.2) into its host and port components.
- *
- * Returns `null` for a missing, blank or unparseable header. The port is `-1` when the header
- * carries none or an out-of-range one - the "no explicit port" sentinel the callers expect;
- * it is never a value okhttp's `HttpUrl.Builder.port` would reject.
- *
- * Bracketed IPv6 literals (`[::1]`, `[::1]:8080`) are delegated to [URI], which knows the
- * `[...]` grammar; anything [URI] rejects or does not treat as a server-based authority
- * (e.g. registry-style names with underscores) falls back to a plain colon split so
- * previously working Host headers keep working.
+ * Splits an HTTP `Host` header into host and port, returning `null` for a missing, blank or
+ * unparseable header and `-1` as the port when there is no explicit, in-range one. Bracketed
+ * IPv6 literals are handled by [URI]; anything it rejects falls back to a plain colon split.
  */
 internal fun hostAndPortFromHostHeader(hostHeader: String?): Pair<String, Int>? {
     val header = hostHeader?.takeIf { it.isNotBlank() } ?: return null
@@ -152,8 +145,6 @@ internal fun hostAndPortFromHostHeader(hostHeader: String?): Pair<String, Int>? 
         if (uri.host != null) return uri.host to uri.port.asHostHeaderPort()
     }
 
-    // URI could not parse it. A bracketed literal it rejected (unclosed bracket,
-    // non-numeric port, ...) is not something the colon split can salvage either.
     if (header.startsWith("[")) return null
 
     val hostPort = header.split(":")
@@ -161,5 +152,4 @@ internal fun hostAndPortFromHostHeader(hostHeader: String?): Pair<String, Int>? 
     return hostPort[0] to port
 }
 
-/** A port is only meaningful when it is a real TCP port; anything else becomes the `-1` sentinel. */
 private fun Int.asHostHeaderPort(): Int = if (this in 1..65535) this else -1

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt
@@ -281,19 +281,15 @@ class NettyWrapper
                 HttpUrl
                     .Builder()
                     .scheme(scheme)
-                    .host(hostAndPortFromHostHeader()?.first ?: address.hostName)
-                    .port(hostAndPortFromHostHeader()?.second ?: port)
+                    .host(hostHeaderWithExplicitPort()?.first ?: address.hostName)
+                    .port(hostHeaderWithExplicitPort()?.second ?: port)
                     .build()
                     .resolve(this.uri())!!
 
-            private fun FullHttpRequest.hostAndPortFromHostHeader(): Pair<String, Int>? =
-                this.headers()["Host"]?.let {
-                    if (it.substringAfter(":").toIntOrNull() != null) {
-                        it.substringBefore(":") to it.substringAfter(":").toInt()
-                    } else {
-                        null
-                    }
-                }
+            // Only override the connection's host/port when the Host header carries an explicit,
+            // usable port; a bare host (port -1) leaves both builder calls on their fallbacks.
+            private fun FullHttpRequest.hostHeaderWithExplicitPort(): Pair<String, Int>? =
+                hostAndPortFromHostHeader(this.headers()["Host"])?.takeIf { (_, port) -> port != -1 }
 
             private fun HttpHeaders.toOkHttpHeaders(): Headers {
                 val headers = Headers.headersOf().newBuilder()

--- a/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt
+++ b/src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt
@@ -286,8 +286,6 @@ class NettyWrapper
                     .build()
                     .resolve(this.uri())!!
 
-            // Only override the connection's host/port when the Host header carries an explicit,
-            // usable port; a bare host (port -1) leaves both builder calls on their fallbacks.
             private fun FullHttpRequest.hostHeaderWithExplicitPort(): Pair<String, Int>? =
                 hostAndPortFromHostHeader(this.headers()["Host"])?.takeIf { (_, port) -> port != -1 }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/e2e/WellKnownIntegrationTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/e2e/WellKnownIntegrationTest.kt
@@ -4,9 +4,11 @@ import io.kotest.assertions.asClue
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldStartWith
 import no.nav.security.mock.oauth2.testutils.client
 import no.nav.security.mock.oauth2.testutils.get
 import no.nav.security.mock.oauth2.withMockOAuth2Server
+import okhttp3.Headers
 import org.junit.jupiter.api.Test
 import tools.jackson.module.kotlin.jacksonObjectMapper
 import tools.jackson.module.kotlin.readValue
@@ -38,6 +40,32 @@ class WellKnownIntegrationTest {
                         "id_token_signing_alg_values_supported",
                         "code_challenge_methods_supported",
                     )
+            }
+        }
+    }
+
+    @Test
+    fun `get to well-known url with IPv6 host header should not crash and reflect the proxy-aware issuer`() {
+        withMockOAuth2Server {
+            val port = this.wellKnownUrl("default").port
+            val response =
+                client.get(
+                    this.wellKnownUrl("default"),
+                    headers = Headers.headersOf("host", "[::1]:$port"),
+                )
+            val body = response.body.string()
+            response.code shouldBe 200
+            jacksonObjectMapper().readValue<Map<String, Any>>(body).asClue { metadata ->
+                metadata["issuer"] shouldBe "http://[::1]:$port/default"
+                listOf(
+                    "authorization_endpoint",
+                    "end_session_endpoint",
+                    "revocation_endpoint",
+                    "token_endpoint",
+                    "userinfo_endpoint",
+                    "jwks_uri",
+                    "introspection_endpoint",
+                ).forEach { (metadata[it] as String) shouldStartWith "http://[::1]:$port/default/" }
             }
         }
     }

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -174,6 +174,87 @@ internal class OAuth2HttpRequestTest {
                 originalUrl = "https://somehost/mypath?query=1".toHttpUrl(),
             )
         req8.proxyAwareUrl().toString() shouldBe "https://oauth2/mypath?query=1"
+
+        // IPv6 host header with port
+        val req9 =
+            OAuth2HttpRequest(
+                headers =
+                    Headers.headersOf(
+                        "host",
+                        "[::1]:8080",
+                    ),
+                method = "GET",
+                originalUrl = "http://[::1]:8080/mypath?query=1".toHttpUrl(),
+            )
+        req9.proxyAwareUrl().toString() shouldBe "http://[::1]:8080/mypath?query=1"
+
+        // IPv6 host header without port
+        val req10 =
+            OAuth2HttpRequest(
+                headers =
+                    Headers.headersOf(
+                        "host",
+                        "[::1]",
+                        "x-forwarded-proto",
+                        "https",
+                    ),
+                method = "GET",
+                originalUrl = "http://[::1]:8080/mypath?query=1".toHttpUrl(),
+            )
+        req10.proxyAwareUrl().toString() shouldBe "https://[::1]/mypath?query=1"
+
+        // malformed IPv6 host header must not throw - fall back to the original url (issue #1022)
+        val req11 =
+            OAuth2HttpRequest(
+                headers =
+                    Headers.headersOf(
+                        "host",
+                        "[::1",
+                    ),
+                method = "GET",
+                originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl(),
+            )
+        req11.proxyAwareUrl().toString() shouldBe "http://localhost:8080/mypath?query=1"
+
+        // IPv6 host header with an out-of-range port must not throw either (issue #1022)
+        val req12 =
+            OAuth2HttpRequest(
+                headers =
+                    Headers.headersOf(
+                        "host",
+                        "[::1]:99999",
+                    ),
+                method = "GET",
+                originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl(),
+            )
+        req12.proxyAwareUrl().toString() shouldBe "http://[::1]:8080/mypath?query=1"
+    }
+
+    @Test
+    fun `hostAndPortFromHostHeader splits host and port for all Host header shapes`() {
+        hostAndPortFromHostHeader(null) shouldBe null
+        hostAndPortFromHostHeader("") shouldBe null
+        hostAndPortFromHostHeader("   ") shouldBe null
+
+        hostAndPortFromHostHeader("localhost") shouldBe ("localhost" to -1)
+        hostAndPortFromHostHeader("fakedings.nais.io:666") shouldBe ("fakedings.nais.io" to 666)
+
+        hostAndPortFromHostHeader("[::1]") shouldBe ("[::1]" to -1)
+        hostAndPortFromHostHeader("[::1]:8080") shouldBe ("[::1]" to 8080)
+        hostAndPortFromHostHeader("[2001:db8::1]:443") shouldBe ("[2001:db8::1]" to 443)
+
+        // unparseable input must not throw
+        hostAndPortFromHostHeader("[::1") shouldBe null
+        hostAndPortFromHostHeader("[::1]:notaport") shouldBe null
+        hostAndPortFromHostHeader("oauth2:notaport") shouldBe ("oauth2" to -1)
+
+        // out-of-range ports collapse to the "no port" sentinel so HttpUrl.Builder never rejects them
+        hostAndPortFromHostHeader("[::1]:99999") shouldBe ("[::1]" to -1)
+        hostAndPortFromHostHeader("[::1]:0") shouldBe ("[::1]" to -1)
+        hostAndPortFromHostHeader("oauth2:99999") shouldBe ("oauth2" to -1)
+
+        // registry-style host java.net.URI refuses still works via the colon split
+        hostAndPortFromHostHeader("mock_oauth2_server:8080") shouldBe ("mock_oauth2_server" to 8080)
     }
 
     @Test

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -175,59 +175,26 @@ internal class OAuth2HttpRequestTest {
             )
         req8.proxyAwareUrl().toString() shouldBe "https://oauth2/mypath?query=1"
 
-        // IPv6 host header with port
-        val req9 =
-            OAuth2HttpRequest(
-                headers =
-                    Headers.headersOf(
-                        "host",
-                        "[::1]:8080",
-                    ),
-                method = "GET",
-                originalUrl = "http://[::1]:8080/mypath?query=1".toHttpUrl(),
-            )
-        req9.proxyAwareUrl().toString() shouldBe "http://[::1]:8080/mypath?query=1"
+        "http://[::1]:8080/mypath?query=1"
+            .get("host", "[::1]:8080")
+            .proxyAwareUrl()
+            .toString() shouldBe "http://[::1]:8080/mypath?query=1"
 
-        // IPv6 host header without port
-        val req10 =
-            OAuth2HttpRequest(
-                headers =
-                    Headers.headersOf(
-                        "host",
-                        "[::1]",
-                        "x-forwarded-proto",
-                        "https",
-                    ),
-                method = "GET",
-                originalUrl = "http://[::1]:8080/mypath?query=1".toHttpUrl(),
-            )
-        req10.proxyAwareUrl().toString() shouldBe "https://[::1]/mypath?query=1"
+        "http://[::1]:8080/mypath?query=1"
+            .get("host", "[::1]", "x-forwarded-proto", "https")
+            .proxyAwareUrl()
+            .toString() shouldBe "https://[::1]/mypath?query=1"
 
-        // malformed IPv6 host header must not throw - fall back to the original url (issue #1022)
-        val req11 =
-            OAuth2HttpRequest(
-                headers =
-                    Headers.headersOf(
-                        "host",
-                        "[::1",
-                    ),
-                method = "GET",
-                originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl(),
-            )
-        req11.proxyAwareUrl().toString() shouldBe "http://localhost:8080/mypath?query=1"
+        // a malformed or out-of-range Host header falls back to the original url instead of throwing (issue #1022)
+        "http://localhost:8080/mypath?query=1"
+            .get("host", "[::1")
+            .proxyAwareUrl()
+            .toString() shouldBe "http://localhost:8080/mypath?query=1"
 
-        // IPv6 host header with an out-of-range port must not throw either (issue #1022)
-        val req12 =
-            OAuth2HttpRequest(
-                headers =
-                    Headers.headersOf(
-                        "host",
-                        "[::1]:99999",
-                    ),
-                method = "GET",
-                originalUrl = "http://localhost:8080/mypath?query=1".toHttpUrl(),
-            )
-        req12.proxyAwareUrl().toString() shouldBe "http://[::1]:8080/mypath?query=1"
+        "http://localhost:8080/mypath?query=1"
+            .get("host", "[::1]:99999")
+            .proxyAwareUrl()
+            .toString() shouldBe "http://[::1]:8080/mypath?query=1"
     }
 
     @Test
@@ -243,17 +210,16 @@ internal class OAuth2HttpRequestTest {
         hostAndPortFromHostHeader("[::1]:8080") shouldBe ("[::1]" to 8080)
         hostAndPortFromHostHeader("[2001:db8::1]:443") shouldBe ("[2001:db8::1]" to 443)
 
-        // unparseable input must not throw
         hostAndPortFromHostHeader("[::1") shouldBe null
         hostAndPortFromHostHeader("[::1]:notaport") shouldBe null
         hostAndPortFromHostHeader("oauth2:notaport") shouldBe ("oauth2" to -1)
 
-        // out-of-range ports collapse to the "no port" sentinel so HttpUrl.Builder never rejects them
+        // out-of-range ports collapse to -1 so HttpUrl.Builder never rejects them
         hostAndPortFromHostHeader("[::1]:99999") shouldBe ("[::1]" to -1)
         hostAndPortFromHostHeader("[::1]:0") shouldBe ("[::1]" to -1)
         hostAndPortFromHostHeader("oauth2:99999") shouldBe ("oauth2" to -1)
 
-        // registry-style host java.net.URI refuses still works via the colon split
+        // registry-style names java.net.URI refuses still work via the colon split
         hostAndPortFromHostHeader("mock_oauth2_server:8080") shouldBe ("mock_oauth2_server" to 8080)
     }
 

--- a/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt
@@ -185,7 +185,7 @@ internal class OAuth2HttpRequestTest {
             .proxyAwareUrl()
             .toString() shouldBe "https://[::1]/mypath?query=1"
 
-        // a malformed or out-of-range Host header falls back to the original url instead of throwing (issue #1022)
+        // a malformed or out-of-range Host header falls back to the original url instead of throwing
         "http://localhost:8080/mypath?query=1"
             .get("host", "[::1")
             .proxyAwareUrl()

--- a/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
@@ -83,6 +83,24 @@ internal class OAuth2HttpServerTest {
     }
 
     @Test
+    fun `Netty server should serve requests with an IPv6 Host header instead of dropping the connection`() {
+        val server = NettyWrapper().start(requestHandler)
+        try {
+            // bracketed IPv6 literal, with and without a port, and a malformed one
+            listOf("[::1]:8080", "[::1]", "[::1", "[::1]:99999").forEach { hostHeader ->
+                httpClient
+                    .get(server.url("/1/2"), Headers.headersOf("Host", hostHeader))
+                    .use {
+                        it.code shouldBe 200
+                        it.body.string() shouldBe "pathmatch"
+                    }
+            }
+        } finally {
+            server.stop()
+        }
+    }
+
+    @Test
     fun `Netty server should reject request bodies exceeding the max content length`() {
         val server = NettyWrapper().start(requestHandler)
         try {

--- a/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
+++ b/src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt
@@ -86,7 +86,6 @@ internal class OAuth2HttpServerTest {
     fun `Netty server should serve requests with an IPv6 Host header instead of dropping the connection`() {
         val server = NettyWrapper().start(requestHandler)
         try {
-            // bracketed IPv6 literal, with and without a port, and a malformed one
             listOf("[::1]:8080", "[::1]", "[::1", "[::1]:99999").forEach { hostHeader ->
                 httpClient
                     .get(server.url("/1/2"), Headers.headersOf("Host", hostHeader))


### PR DESCRIPTION
This pull request improves how the server parses and handles HTTP `Host` headers, especially for IPv6 addresses and malformed input. The main changes include introducing a robust utility for splitting host and port from the `Host` header, updating server logic to use this utility, and expanding test coverage for edge cases.

**Host header parsing improvements:**

* Added a new internal function `hostAndPortFromHostHeader` that correctly splits host and port from the `Host` header, with special handling for bracketed IPv6 literals and malformed input. Ports outside the valid range now default to `-1` instead of causing errors. (`src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt`, [src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.ktR135-R155](diffhunk://#diff-3ab9cb664cfad177a80d548b8d7064094212eb2c7522d82a3540fe060a995179R135-R155))
* Updated `OAuth2HttpRequest` to use the new `hostAndPortFromHostHeader` utility, replacing the previous parsing logic. (`src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.kt`, [src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequest.ktL124-R125](diffhunk://#diff-3ab9cb664cfad177a80d548b8d7064094212eb2c7522d82a3540fe060a995179L124-R125))
* Refactored the Netty server (`NettyWrapper`) to use the new parsing function, ensuring only explicit, valid ports are used from the `Host` header. (`src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.kt`, [src/main/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpServer.ktL284-R290](diffhunk://#diff-499bbe9a985a79e509a505ae8bee1b7c633e7bd781f147939c61d7aa941349caL284-R290))

**Testing and validation:**

* Added and expanded tests to cover all `Host` header shapes, including various IPv6 formats, missing and malformed headers, and out-of-range ports. This ensures robust handling and prevents crashes or unexpected behavior. (`src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.kt`, [src/test/kotlin/no/nav/security/mock/oauth2/http/OAuth2HttpRequestTest.ktR177-R223](diffhunk://#diff-af850122bf29f459870d6fb948b9cc47768e207e6eda87daadbebd57f906a73dR177-R223))
* Added integration tests to verify that requests with IPv6 `Host` headers are handled correctly and that the server does not crash or drop connections. (`src/test/kotlin/no/nav/security/mock/oauth2/e2e/WellKnownIntegrationTest.kt`, [[1]](diffhunk://#diff-7d30c14df28f95a521edc8eba09a2195f5d5725b58d912530912e6c6e6971103R46-R71); `src/test/kotlin/no/nav/security/mock/oauth2/server/OAuth2HttpServerTest.kt`, [[2]](diffhunk://#diff-a455cbef990fba837135650d89bbefbf2b2c2f7a149f8ebea818bb6dbcd692d8R85-R101)

These changes make the server more robust and proxy-aware, especially in environments using IPv6 or non-standard `Host` headers.